### PR TITLE
Set FLAG_SECURE to disable screenshots

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
@@ -33,7 +33,6 @@ import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -68,7 +67,7 @@ import java.net.SocketAddress;
 import java.nio.channels.FileChannel;
 import java.util.Date;
 
-public class LoginActivity extends AppCompatActivity
+public class LoginActivity extends SecureActivity
         implements LoginFragment.Listener, GenerateFragment.Listener,
         GenerateReviewFragment.Listener, GenerateReviewFragment.AcceptListener, ReceiveFragment.Listener {
     static final String TAG = "LoginActivity";

--- a/app/src/main/java/com/m2049r/xmrwallet/SecureActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/SecureActivity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017 m2049r
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.m2049r.xmrwallet;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import static android.view.WindowManager.LayoutParams;
+
+public abstract class SecureActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // set FLAG_SECURE to prevent screenshots
+        getWindow().setFlags(LayoutParams.FLAG_SECURE, LayoutParams.FLAG_SECURE);
+    }
+}

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -31,7 +31,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -51,7 +50,7 @@ import com.m2049r.xmrwallet.util.TxData;
 import java.util.HashMap;
 import java.util.Map;
 
-public class WalletActivity extends AppCompatActivity implements WalletFragment.Listener,
+public class WalletActivity extends SecureActivity implements WalletFragment.Listener,
         WalletService.Observer, SendFragment.Listener, TxFragment.Listener,
         GenerateReviewFragment.ListenerWithWallet,
         GenerateReviewFragment.Listener,


### PR DESCRIPTION
Taiga: https://taiga.getmonero.org/project/m2049r-monerujo/us/38

Sets FLAG_SECURE on all activities to prevent users accidentally
screenshotting sensitive information.

***

>how do we let him do this in the future? settings? button "enable screenshot"?

I don't think we should let him do it in the future. Banking apps have screenshots disabled and no option to enable it because it just isn't needed.