### PR TITLE
Feature/timber logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile 'me.dm7.barcodescanner:zxing:1.9.8'
 
     compile "com.squareup.okhttp3:okhttp:$rootProject.ext.okHttpVersion"
+    compile "com.jakewharton.timber:timber:$rootProject.ext.timberVersion"
 
     testCompile "junit:junit:$rootProject.ext.junitVersion"
     testCompile "org.mockito:mockito-all:$rootProject.ext.mockitoVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:name=".XmrWalletApplication"
         android:theme="@style/MyMaterialTheme">
 
         <activity

--- a/app/src/main/java/com/m2049r/xmrwallet/GenerateFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/GenerateFragment.java
@@ -22,7 +22,6 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.Fragment;
 import android.text.InputType;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -40,8 +39,9 @@ import com.m2049r.xmrwallet.util.Helper;
 
 import java.io.File;
 
+import timber.log.Timber;
+
 public class GenerateFragment extends Fragment {
-    static final String TAG = "GenerateFragment";
 
     static final String TYPE = "type";
     static final String TYPE_NEW = "new";
@@ -366,7 +366,7 @@ public class GenerateFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         activityCallback.setTitle(getString(R.string.generate_title) + " - " + getType());
         activityCallback.setToolbarButton(Toolbar.BUTTON_BACK);
 
@@ -383,7 +383,7 @@ public class GenerateFragment extends Fragment {
             case TYPE_VIEWONLY:
                 return getString(R.string.generate_wallet_type_view);
             default:
-                Log.e(TAG, "unknown type " + type);
+                Timber.e("unknown type %s", type);
                 return "?";
         }
     }

--- a/app/src/main/java/com/m2049r/xmrwallet/GenerateReviewFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/GenerateReviewFragment.java
@@ -21,7 +21,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -41,8 +40,9 @@ import com.m2049r.xmrwallet.model.WalletManager;
 import com.m2049r.xmrwallet.util.Helper;
 import com.m2049r.xmrwallet.util.MoneroThreadPoolExecutor;
 
+import timber.log.Timber;
+
 public class GenerateReviewFragment extends Fragment {
-    static final String TAG = "GenerateReviewFragment";
     static final public String VIEW_TYPE_DETAILS = "details";
     static final public String VIEW_TYPE_ACCEPT = "accept";
     static final public String VIEW_TYPE_WALLET = "wallet";
@@ -264,7 +264,7 @@ public class GenerateReviewFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         String name = tvWalletName.getText().toString();
         if (name.isEmpty()) name = null;
         activityCallback.setTitle(name, getString(R.string.details_title));

--- a/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
@@ -35,7 +35,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -67,10 +66,11 @@ import java.net.SocketAddress;
 import java.nio.channels.FileChannel;
 import java.util.Date;
 
+import timber.log.Timber;
+
 public class LoginActivity extends SecureActivity
         implements LoginFragment.Listener, GenerateFragment.Listener,
         GenerateReviewFragment.Listener, GenerateReviewFragment.AcceptListener, ReceiveFragment.Listener {
-    static final String TAG = "LoginActivity";
     private static final String GENERATE_STACK = "gen";
 
     static final int DAEMON_TIMEOUT = 500; // deamon must respond in 500ms
@@ -99,7 +99,7 @@ public class LoginActivity extends SecureActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.d(TAG, "onCreate()");
+        Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
             // we don't store anything ourselves
@@ -125,7 +125,7 @@ public class LoginActivity extends SecureActivity
                         break;
                     case Toolbar.BUTTON_NONE:
                     default:
-                        Log.e(TAG, "Button " + type + "pressed - how can this be?");
+                        Timber.e("Button " + type + "pressed - how can this be?");
                 }
             }
         });
@@ -133,7 +133,7 @@ public class LoginActivity extends SecureActivity
         if (Helper.getWritePermission(this)) {
             if (savedInstanceState == null) startLoginFragment();
         } else {
-            Log.i(TAG, "Waiting for permissions");
+            Timber.i("Waiting for permissions");
         }
     }
 
@@ -157,7 +157,7 @@ public class LoginActivity extends SecureActivity
             WalletNode aWalletNode = new WalletNode(walletName, daemon, testnet);
             new AsyncOpenWallet().execute(aWalletNode);
         } catch (IllegalArgumentException ex) {
-            Log.e(TAG, ex.getLocalizedMessage());
+            Timber.e(ex.getLocalizedMessage());
             Toast.makeText(this, ex.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
             return false;
         }
@@ -167,7 +167,7 @@ public class LoginActivity extends SecureActivity
     @Override
     public void onWalletDetails(final String walletName, boolean testnet) {
         setNet(testnet);
-        Log.d(TAG, "details for wallet ." + walletName + ".");
+        Timber.d("details for wallet ." + walletName + ".");
         if (checkServiceRunning()) return;
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             @Override
@@ -183,7 +183,7 @@ public class LoginActivity extends SecureActivity
                                 }
                             });
                         } else { // this cannot really happen as we prefilter choices
-                            Log.e(TAG, "Wallet missing: " + walletName);
+                            Timber.e("Wallet missing: %s", walletName);
                             Toast.makeText(LoginActivity.this, getString(R.string.bad_wallet), Toast.LENGTH_SHORT).show();
                         }
                         break;
@@ -205,7 +205,7 @@ public class LoginActivity extends SecureActivity
     @Override
     public void onWalletReceive(String walletName, boolean testnet) {
         setNet(testnet);
-        Log.d(TAG, "receive for wallet ." + walletName + ".");
+        Timber.d("receive for wallet ." + walletName + ".");
         if (checkServiceRunning()) return;
         final File walletFile = Helper.getWalletFile(this, walletName);
         if (WalletManager.getInstance().walletExists(walletFile)) {
@@ -262,7 +262,7 @@ public class LoginActivity extends SecureActivity
 
     @Override
     public void onWalletRename(final String walletName) {
-        Log.d(TAG, "rename for wallet ." + walletName + ".");
+        Timber.d("rename for wallet ." + walletName + ".");
         if (checkServiceRunning()) return;
         LayoutInflater li = LayoutInflater.from(this);
         View promptsView = li.inflate(R.layout.prompt_rename, null);
@@ -345,7 +345,7 @@ public class LoginActivity extends SecureActivity
         File backupFolder = new File(getStorageRoot(), "backups");
         if (!backupFolder.exists()) {
             if (!backupFolder.mkdir()) {
-                Log.e(TAG, "Cannot create backup dir " + backupFolder.getAbsolutePath());
+                Timber.e("Cannot create backup dir %s", backupFolder.getAbsolutePath());
                 return false;
             }
             // make folder visible over USB/MTP
@@ -353,18 +353,18 @@ public class LoginActivity extends SecureActivity
         }
         File walletFile = Helper.getWalletFile(LoginActivity.this, walletName);
         File backupFile = new File(backupFolder, walletName);
-        Log.d(TAG, "backup " + walletFile.getAbsolutePath() + " to " + backupFile.getAbsolutePath());
+        Timber.d("backup " + walletFile.getAbsolutePath() + " to " + backupFile.getAbsolutePath());
         // TODO probably better to copy to a new file and then rename
         // then if something fails we have the old backup at least
         // or just create a new backup every time and keep n old backups
         boolean success = copyWallet(walletFile, backupFile, true, true);
-        Log.d(TAG, "copyWallet is " + success);
+        Timber.d("copyWallet is %s", success);
         return success;
     }
 
     @Override
     public void onWalletBackup(String walletName) {
-        Log.d(TAG, "backup for wallet ." + walletName + ".");
+        Timber.d("backup for wallet ." + walletName + ".");
         new AsyncBackup().execute(walletName);
     }
 
@@ -403,7 +403,7 @@ public class LoginActivity extends SecureActivity
 
     @Override
     public void onWalletArchive(final String walletName) {
-        Log.d(TAG, "archive for wallet ." + walletName + ".");
+        Timber.d("archive for wallet ." + walletName + ".");
         if (checkServiceRunning()) return;
         DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
             @Override
@@ -428,7 +428,7 @@ public class LoginActivity extends SecureActivity
     }
 
     void reloadWalletList() {
-        Log.d(TAG, "reloadWalletList()");
+        Timber.d("reloadWalletList()");
         try {
             LoginFragment loginFragment = (LoginFragment)
                     getSupportFragmentManager().findFragmentById(R.id.fragment_container);
@@ -585,7 +585,7 @@ public class LoginActivity extends SecureActivity
 
     @Override
     protected void onPause() {
-        Log.d(TAG, "onPause()");
+        Timber.d("onPause()");
         super.onPause();
     }
 
@@ -626,7 +626,7 @@ public class LoginActivity extends SecureActivity
     @Override
     protected void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         // wait for WalletService to finish
         if (WalletService.Running && (progressDialog == null)) {
             // and show a progress dialog, but only if there isn't one already
@@ -681,7 +681,7 @@ public class LoginActivity extends SecureActivity
     }
 
     void startWallet(String walletName, String walletPassword) {
-        Log.d(TAG, "startWallet()");
+        Timber.d("startWallet()");
         Intent intent = new Intent(getApplicationContext(), WalletActivity.class);
         intent.putExtra(WalletActivity.REQUEST_ID, walletName);
         intent.putExtra(WalletActivity.REQUEST_PW, walletPassword);
@@ -689,7 +689,7 @@ public class LoginActivity extends SecureActivity
     }
 
     void startDetails(File walletFile, String password, String type) {
-        Log.d(TAG, "startDetails()");
+        Timber.d("startDetails()");
         Bundle b = new Bundle();
         b.putString("path", walletFile.getAbsolutePath());
         b.putString("password", password);
@@ -698,7 +698,7 @@ public class LoginActivity extends SecureActivity
     }
 
     void startReceive(File walletFile, String password) {
-        Log.d(TAG, "startReceive()");
+        Timber.d("startReceive()");
         Bundle b = new Bundle();
         b.putString("path", walletFile.getAbsolutePath());
         b.putString("password", password);
@@ -707,7 +707,7 @@ public class LoginActivity extends SecureActivity
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
-        Log.d(TAG, "onRequestPermissionsResult()");
+        Timber.d("onRequestPermissionsResult()");
         switch (requestCode) {
             case Helper.PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE:
                 // If request is cancelled, the result arrays are empty.
@@ -716,7 +716,7 @@ public class LoginActivity extends SecureActivity
                     startLoginFragment = true;
                 } else {
                     String msg = getString(R.string.message_strorage_not_permitted);
-                    Log.e(TAG, msg);
+                    Timber.e(msg);
                     Toast.makeText(this, msg, Toast.LENGTH_LONG).show();
                     //throw new IllegalStateException(msg);
                 }
@@ -740,24 +740,24 @@ public class LoginActivity extends SecureActivity
         Fragment fragment = new LoginFragment();
         getSupportFragmentManager().beginTransaction()
                 .add(R.id.fragment_container, fragment).commit();
-        Log.d(TAG, "LoginFragment added");
+        Timber.d("LoginFragment added");
     }
 
     void startGenerateFragment(String type) {
         Bundle extras = new Bundle();
         extras.putString(GenerateFragment.TYPE, type);
         replaceFragment(new GenerateFragment(), GENERATE_STACK, extras);
-        Log.d(TAG, "GenerateFragment placed");
+        Timber.d("GenerateFragment placed");
     }
 
     void startReviewFragment(Bundle extras) {
         replaceFragment(new GenerateReviewFragment(), null, extras);
-        Log.d(TAG, "GenerateReviewFragment placed");
+        Timber.d("GenerateReviewFragment placed");
     }
 
     void startReceiveFragment(Bundle extras) {
         replaceFragment(new ReceiveFragment(), null, extras);
-        Log.d(TAG, "ReceiveFragment placed");
+        Timber.d("ReceiveFragment placed");
     }
 
     void replaceFragment(Fragment newFragment, String stackName, Bundle extras) {
@@ -803,7 +803,7 @@ public class LoginActivity extends SecureActivity
         protected Boolean doInBackground(Void... params) {
             File newWalletFolder = getStorageRoot();
             if (!newWalletFolder.isDirectory()) {
-                Log.e(TAG, "Wallet dir " + newWalletFolder.getAbsolutePath() + "is not a directory");
+                Timber.e("Wallet dir " + newWalletFolder.getAbsolutePath() + "is not a directory");
                 return false;
             }
             File cacheFile = new File(newWalletFolder, walletName);
@@ -811,7 +811,7 @@ public class LoginActivity extends SecureActivity
             File addressFile = new File(newWalletFolder, walletName + ".address.txt");
 
             if (cacheFile.exists() || keysFile.exists() || addressFile.exists()) {
-                Log.e(TAG, "Some wallet files already exist for " + cacheFile.getAbsolutePath());
+                Timber.e("Some wallet files already exist for %s", cacheFile.getAbsolutePath());
                 return false;
             }
 
@@ -820,7 +820,7 @@ public class LoginActivity extends SecureActivity
             if (success) {
                 return true;
             } else {
-                Log.e(TAG, "Could not create new wallet in " + newWalletFile.getAbsolutePath());
+                Timber.e("Could not create new wallet in %s", newWalletFile.getAbsolutePath());
                 return false;
             }
         }
@@ -851,7 +851,7 @@ public class LoginActivity extends SecureActivity
                     getSupportFragmentManager().findFragmentById(R.id.fragment_container);
             genFragment.walletGenerateError();
         } catch (ClassCastException ex) {
-            Log.e(TAG, "walletGenerateError() but not in GenerateFragment");
+            Timber.e("walletGenerateError() but not in GenerateFragment");
         }
     }
 
@@ -869,7 +869,7 @@ public class LoginActivity extends SecureActivity
                                 .createWallet(aFile, password, MNEMONIC_LANGUAGE);
                         boolean success = (newWallet.getStatus() == Wallet.Status.Status_Ok);
                         if (!success) {
-                            Log.e(TAG, newWallet.getErrorString());
+                            Timber.e(newWallet.getErrorString());
                             toast(newWallet.getErrorString());
                         }
                         newWallet.close();
@@ -889,7 +889,7 @@ public class LoginActivity extends SecureActivity
                             newWallet.setPassword(password);
                             success = success && newWallet.store();
                         } else {
-                            Log.e(TAG, newWallet.getErrorString());
+                            Timber.e(newWallet.getErrorString());
                             toast(newWallet.getErrorString());
                         }
                         newWallet.close();
@@ -912,7 +912,7 @@ public class LoginActivity extends SecureActivity
                             newWallet.setPassword(password);
                             success = success && newWallet.store();
                         } else {
-                            Log.e(TAG, newWallet.getErrorString());
+                            Timber.e(newWallet.getErrorString());
                             toast(newWallet.getErrorString());
                         }
                         newWallet.close();
@@ -943,17 +943,17 @@ public class LoginActivity extends SecureActivity
             Toast.makeText(LoginActivity.this,
                     getString(R.string.generate_wallet_created), Toast.LENGTH_SHORT).show();
         } else {
-            Log.e(TAG, "Wallet store failed to " + walletFile.getAbsolutePath());
+            Timber.e("Wallet store failed to %s", walletFile.getAbsolutePath());
             Toast.makeText(LoginActivity.this, getString(R.string.generate_wallet_create_failed), Toast.LENGTH_LONG).show();
         }
     }
 
     Wallet.Status testWallet(String path, String password) {
-        Log.d(TAG, "testing wallet " + path);
+        Timber.d("testing wallet %s", path);
         Wallet aWallet = WalletManager.getInstance().openWallet(path, password);
         if (aWallet == null) return Wallet.Status.Status_Error; // does this ever happen?
         Wallet.Status status = aWallet.getStatus();
-        Log.d(TAG, "wallet tested " + aWallet.getStatus());
+        Timber.d("wallet tested %s", aWallet.getStatus());
         aWallet.close();
         return status;
     }
@@ -983,7 +983,7 @@ public class LoginActivity extends SecureActivity
             try {
                 copyFile(new File(srcDir, srcName), new File(dstDir, dstName));
             } catch (IOException ex) {
-                Log.d(TAG, "CACHE " + ignoreCacheError);
+                Timber.d("CACHE %s", ignoreCacheError);
                 if (!ignoreCacheError) { // ignore cache backup error if backing up (can be resynced)
                     throw ex;
                 }
@@ -992,7 +992,7 @@ public class LoginActivity extends SecureActivity
             copyFile(new File(srcDir, srcName + ".address.txt"), new File(dstDir, dstName + ".address.txt"));
             success = true;
         } catch (IOException ex) {
-            Log.e(TAG, "wallet copy failed: " + ex.getMessage());
+            Timber.e("wallet copy failed: %s", ex.getMessage());
             // try to rollback
             deleteWallet(dstWallet);
         }
@@ -1001,7 +1001,7 @@ public class LoginActivity extends SecureActivity
 
     // do our best to delete as much as possible of the wallet files
     boolean deleteWallet(File walletFile) {
-        Log.d(TAG, "deleteWallet " + walletFile.getAbsolutePath());
+        Timber.d("deleteWallet %s", walletFile.getAbsolutePath());
         File dir = walletFile.getParentFile();
         String name = walletFile.getName();
         boolean success = true;
@@ -1014,7 +1014,7 @@ public class LoginActivity extends SecureActivity
         if (addressFile.exists()) {
             success = addressFile.delete() && success;
         }
-        Log.d(TAG, "deleteWallet is " + success);
+        Timber.d("deleteWallet is %s", success);
         return success;
     }
 
@@ -1164,26 +1164,26 @@ public class LoginActivity extends SecureActivity
             this.walletNode = params[0];
             if (!walletNode.isValid()) return INVALID;
 
-            Log.d(TAG, "checking " + walletNode.getAddress());
+            Timber.d("checking %s", walletNode.getAddress());
 
             try {
                 long timeDA = new Date().getTime();
                 SocketAddress address = new InetSocketAddress(walletNode.host, walletNode.port);
                 long timeDB = new Date().getTime();
-                Log.d(TAG, "Resolving " + walletNode.host + " took " + (timeDB - timeDA) + "ms.");
+                Timber.d("Resolving " + walletNode.host + " took " + (timeDB - timeDA) + "ms.");
                 Socket socket = new Socket();
                 long timeA = new Date().getTime();
                 socket.connect(address, LoginActivity.DAEMON_TIMEOUT);
                 socket.close();
                 long timeB = new Date().getTime();
                 long time = timeB - timeA;
-                Log.d(TAG, "Daemon " + walletNode.host + " is " + time + "ms away.");
+                Timber.d("Daemon " + walletNode.host + " is " + time + "ms away.");
                 return (time < LoginActivity.DAEMON_TIMEOUT ? OK : TIMEOUT);
             } catch (IOException ex) {
-                Log.d(TAG, "Cannot reach daemon " + walletNode.host + "/" + walletNode.port + " because " + ex.getMessage());
+                Timber.d("Cannot reach daemon " + walletNode.host + "/" + walletNode.port + " because " + ex.getMessage());
                 return IOEX;
             } catch (IllegalArgumentException ex) {
-                Log.d(TAG, "Cannot reach daemon " + walletNode.host + "/" + walletNode.port + " because " + ex.getMessage());
+                Timber.d("Cannot reach daemon " + walletNode.host + "/" + walletNode.port + " because " + ex.getMessage());
                 return INVALID;
             }
         }
@@ -1197,7 +1197,7 @@ public class LoginActivity extends SecureActivity
             dismissProgressDialog();
             switch (result) {
                 case OK:
-                    Log.d(TAG, "selected wallet is ." + walletNode.name + ".");
+                    Timber.d("selected wallet is ." + walletNode.name + ".");
                     // now it's getting real, check if wallet exists
                     promptAndStart(walletNode);
                     break;

--- a/app/src/main/java/com/m2049r/xmrwallet/LoginFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/LoginFragment.java
@@ -24,7 +24,6 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -55,9 +54,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import timber.log.Timber;
+
 public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInteractionListener,
         View.OnClickListener {
-    private static final String TAG = "LoginFragment";
 
     private WalletInfoAdapter adapter;
 
@@ -112,7 +112,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
 
     @Override
     public void onPause() {
-        Log.d(TAG, "onPause()");
+        Timber.d("onPause()");
         savePrefs();
         super.onPause();
     }
@@ -120,7 +120,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         activityCallback.setTitle(null);
         activityCallback.setToolbarButton(Toolbar.BUTTON_DONATE);
         activityCallback.showNet(isTestnet());
@@ -129,7 +129,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        Log.d(TAG, "onCreateView");
+        Timber.d("onCreateView");
         View view = inflater.inflate(R.layout.fragment_login, container, false);
 
         ivGunther = (ImageView) view.findViewById(R.id.ivGunther);
@@ -262,7 +262,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
     }
 
     public void loadList() {
-        Log.d(TAG, "loadList()");
+        Timber.d("loadList()");
         WalletManager mgr = WalletManager.getInstance();
         List<WalletManager.WalletInfo> walletInfos =
                 mgr.findWallets(activityCallback.getStorageRoot());
@@ -360,7 +360,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
     }
 
     void savePrefs(boolean usePreviousState) {
-        Log.d(TAG, "SAVE / " + usePreviousState);
+        Timber.d("SAVE / %s", usePreviousState);
         // save the daemon address for the net
         boolean testnet = isTestnet() ^ usePreviousState;
         String daemon = getDaemon();
@@ -383,7 +383,7 @@ public class LoginFragment extends Fragment implements WalletInfoAdapter.OnInter
     }
 
     void setDaemon(NodeList nodeList) {
-        Log.d(TAG, "setDaemon() " + nodeList.toString());
+        Timber.d("setDaemon() %s", nodeList.toString());
         String[] nodes = nodeList.getNodes().toArray(new String[0]);
         nodeAdapter.clear();
         nodeAdapter.addAll(nodes);

--- a/app/src/main/java/com/m2049r/xmrwallet/ReceiveFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/ReceiveFragment.java
@@ -27,7 +27,6 @@ import android.support.v4.app.Fragment;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -57,8 +56,9 @@ import com.m2049r.xmrwallet.util.MoneroThreadPoolExecutor;
 import java.util.HashMap;
 import java.util.Map;
 
+import timber.log.Timber;
+
 public class ReceiveFragment extends Fragment {
-    static final String TAG = "ReceiveFragment";
 
     private ProgressBar pbProgress;
     private TextView tvAddress;
@@ -111,7 +111,7 @@ public class ReceiveFragment extends Fragment {
         evAmount.setOnNewAmountListener(new ExchangeView.OnNewAmountListener() {
             @Override
             public void onNewAmount(String xmr) {
-                Log.d(TAG, "new amount = " + xmr);
+                Timber.d("new amount = %s", xmr);
                 generateQr();
             }
         });
@@ -189,7 +189,7 @@ public class ReceiveFragment extends Fragment {
         Bundle b = getArguments();
         String address = b.getString("address");
         String walletName = b.getString("name");
-        Log.d(TAG, "address=" + address + "/name=" + walletName);
+        Timber.d("address=" + address + "/name=" + walletName);
         if (address == null) {
             String path = b.getString("path");
             String password = b.getString("password");
@@ -227,7 +227,7 @@ public class ReceiveFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         listenerCallback.setToolbarButton(Toolbar.BUTTON_BACK);
         listenerCallback.setSubtitle(getString(R.string.receive_title));
         generateQr();
@@ -236,7 +236,7 @@ public class ReceiveFragment extends Fragment {
     private boolean isLoaded = false;
 
     private void show(String name, String address) {
-        Log.d(TAG, "name=" + name);
+        Timber.d("name=%s", name);
         isLoaded = true;
         listenerCallback.setTitle(name);
         tvAddress.setText(address);
@@ -296,14 +296,14 @@ public class ReceiveFragment extends Fragment {
     }
 
     private void generateQr() {
-        Log.d(TAG, "GENQR");
+        Timber.d("GENQR");
         String address = tvAddress.getText().toString();
         String paymentId = etPaymentId.getEditText().getText().toString();
         String xmrAmount = evAmount.getAmount();
-        Log.d(TAG, xmrAmount + "/" + paymentId + "/" + address);
+        Timber.d(xmrAmount + "/" + paymentId + "/" + address);
         if ((xmrAmount == null) || !Wallet.isAddressValid(address, WalletManager.getInstance().isTestNet())) {
             clearQR();
-            Log.d(TAG, "CLEARQR");
+            Timber.d("CLEARQR");
             return;
         }
         StringBuffer sb = new StringBuffer();
@@ -329,7 +329,7 @@ public class ReceiveFragment extends Fragment {
         Bitmap qr = generate(text, size, size);
         if (qr != null) {
             setQR(qr);
-            Log.d(TAG, "SETQR");
+            Timber.d("SETQR");
             etDummy.requestFocus();
             Helper.hideKeyboard(getActivity());
         }
@@ -352,7 +352,7 @@ public class ReceiveFragment extends Fragment {
                 }
             }
             Bitmap bitmap = Bitmap.createBitmap(pixels, 0, width, width, height, Bitmap.Config.RGB_565);
-            bitmap = addLogo(bitmap);
+            bitmap = addTimbero(bitmap);
             return bitmap;
         } catch (WriterException e) {
             e.printStackTrace();
@@ -361,8 +361,8 @@ public class ReceiveFragment extends Fragment {
     }
 
     // TODO check if we can sensibly cache some of this
-    private Bitmap addLogo(Bitmap qrBitmap) {
-        Bitmap logo = getMoneroLogo();
+    private Bitmap addTimbero(Bitmap qrBitmap) {
+        Bitmap logo = getMoneroTimbero();
         int qrWidth = qrBitmap.getWidth();
         int qrHeight = qrBitmap.getHeight();
         int logoWidth = logo.getWidth();
@@ -386,7 +386,7 @@ public class ReceiveFragment extends Fragment {
 
     private Bitmap logo = null;
 
-    private Bitmap getMoneroLogo() {
+    private Bitmap getMoneroTimbero() {
         if (logo == null) {
             logo = Helper.getBitmap(getContext(), R.drawable.ic_monero_logo_b);
         }
@@ -419,7 +419,7 @@ public class ReceiveFragment extends Fragment {
 
     @Override
     public void onPause() {
-        Log.d(TAG, "onPause()");
+        Timber.d("onPause()");
         super.onPause();
     }
 }

--- a/app/src/main/java/com/m2049r/xmrwallet/ReceiveFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/ReceiveFragment.java
@@ -189,7 +189,7 @@ public class ReceiveFragment extends Fragment {
         Bundle b = getArguments();
         String address = b.getString("address");
         String walletName = b.getString("name");
-        Timber.d("address=" + address + "/name=" + walletName);
+        Timber.d("%s/%s",address, walletName);
         if (address == null) {
             String path = b.getString("path");
             String password = b.getString("password");
@@ -300,7 +300,7 @@ public class ReceiveFragment extends Fragment {
         String address = tvAddress.getText().toString();
         String paymentId = etPaymentId.getEditText().getText().toString();
         String xmrAmount = evAmount.getAmount();
-        Timber.d(xmrAmount + "/" + paymentId + "/" + address);
+        Timber.d("%s/%s/%s",xmrAmount, paymentId, address);
         if ((xmrAmount == null) || !Wallet.isAddressValid(address, WalletManager.getInstance().isTestNet())) {
             clearQR();
             Timber.d("CLEARQR");
@@ -352,7 +352,7 @@ public class ReceiveFragment extends Fragment {
                 }
             }
             Bitmap bitmap = Bitmap.createBitmap(pixels, 0, width, width, height, Bitmap.Config.RGB_565);
-            bitmap = addTimbero(bitmap);
+            bitmap = addLogo(bitmap);
             return bitmap;
         } catch (WriterException e) {
             e.printStackTrace();
@@ -361,8 +361,8 @@ public class ReceiveFragment extends Fragment {
     }
 
     // TODO check if we can sensibly cache some of this
-    private Bitmap addTimbero(Bitmap qrBitmap) {
-        Bitmap logo = getMoneroTimbero();
+    private Bitmap addLogo(Bitmap qrBitmap) {
+        Bitmap logo = getMoneroLogo();
         int qrWidth = qrBitmap.getWidth();
         int qrHeight = qrBitmap.getHeight();
         int logoWidth = logo.getWidth();
@@ -386,7 +386,7 @@ public class ReceiveFragment extends Fragment {
 
     private Bitmap logo = null;
 
-    private Bitmap getMoneroTimbero() {
+    private Bitmap getMoneroLogo() {
         if (logo == null) {
             logo = Helper.getBitmap(getContext(), R.drawable.ic_monero_logo_b);
         }

--- a/app/src/main/java/com/m2049r/xmrwallet/ScannerFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/ScannerFragment.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -30,9 +29,9 @@ import com.google.zxing.BarcodeFormat;
 import com.google.zxing.Result;
 
 import me.dm7.barcodescanner.zxing.ZXingScannerView;
+import timber.log.Timber;
 
 public class ScannerFragment extends Fragment implements ZXingScannerView.ResultHandler {
-    static final String TAG = "ScannerFragment";
 
     private Listener activityCallback;
 
@@ -44,7 +43,7 @@ public class ScannerFragment extends Fragment implements ZXingScannerView.Result
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        Log.d(TAG, "onCreateView");
+        Timber.d("onCreateView");
         mScannerView = new ZXingScannerView(getActivity());
         return mScannerView;
     }
@@ -52,7 +51,7 @@ public class ScannerFragment extends Fragment implements ZXingScannerView.Result
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume");
+        Timber.d("onResume");
         mScannerView.setResultHandler(this);
         mScannerView.startCamera();
     }
@@ -91,7 +90,7 @@ public class ScannerFragment extends Fragment implements ZXingScannerView.Result
 
     @Override
     public void onPause() {
-        Log.d(TAG, "onPause");
+        Timber.d("onPause");
         mScannerView.stopCamera();
         super.onPause();
     }

--- a/app/src/main/java/com/m2049r/xmrwallet/SendFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/SendFragment.java
@@ -352,7 +352,7 @@ public class SendFragment extends Fragment {
         int mixin = Mixins[sMixin.getSelectedItemPosition()];
         int priorityIndex = sPriority.getSelectedItemPosition();
         PendingTransaction.Priority priority = Priorities[priorityIndex];
-        Timber.d(dst_addr + "/" + paymentId + "/" + amount + "/" + mixin + "/" + priority.toString());
+        Timber.d("%s/%s/%d/%d/%s", dst_addr, paymentId, amount, mixin, priority.toString());
         TxData txData = new TxData(
                 dst_addr,
                 paymentId,

--- a/app/src/main/java/com/m2049r/xmrwallet/SendFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/SendFragment.java
@@ -27,7 +27,6 @@ import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -53,8 +52,9 @@ import com.m2049r.xmrwallet.util.BarcodeData;
 import com.m2049r.xmrwallet.util.Helper;
 import com.m2049r.xmrwallet.util.TxData;
 
+import timber.log.Timber;
+
 public class SendFragment extends Fragment {
-    static final String TAG = "SendFragment";
 
     private EditText etDummy;
 
@@ -352,7 +352,7 @@ public class SendFragment extends Fragment {
         int mixin = Mixins[sMixin.getSelectedItemPosition()];
         int priorityIndex = sPriority.getSelectedItemPosition();
         PendingTransaction.Priority priority = Priorities[priorityIndex];
-        Log.d(TAG, dst_addr + "/" + paymentId + "/" + amount + "/" + mixin + "/" + priority.toString());
+        Timber.d(dst_addr + "/" + paymentId + "/" + amount + "/" + mixin + "/" + priority.toString());
         TxData txData = new TxData(
                 dst_addr,
                 paymentId,
@@ -426,12 +426,12 @@ public class SendFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume");
+        Timber.d("onResume");
         activityCallback.setToolbarButton(Toolbar.BUTTON_BACK);
         activityCallback.setSubtitle(getString(R.string.send_title));
         BarcodeData data = activityCallback.popScannedData();
         if (data != null) {
-            Log.d(TAG, "GOT DATA");
+            Timber.d("GOT DATA");
             String scannedAddress = data.address;
             if (scannedAddress != null) {
                 etAddress.getEditText().setText(scannedAddress);

--- a/app/src/main/java/com/m2049r/xmrwallet/TxFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/TxFragment.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.TimeZone;
 
 public class TxFragment extends Fragment {
-    static final String TAG = "TxFragment";
 
     static public final String ARG_INFO = "info";
 

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -31,7 +31,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Toast;
 
@@ -50,12 +49,13 @@ import com.m2049r.xmrwallet.util.TxData;
 import java.util.HashMap;
 import java.util.Map;
 
+import timber.log.Timber;
+
 public class WalletActivity extends SecureActivity implements WalletFragment.Listener,
         WalletService.Observer, SendFragment.Listener, TxFragment.Listener,
         GenerateReviewFragment.ListenerWithWallet,
         GenerateReviewFragment.Listener,
         ScannerFragment.Listener, ReceiveFragment.Listener {
-    private static final String TAG = "WalletActivity";
 
     public static final String REQUEST_ID = "id";
     public static final String REQUEST_PW = "pw";
@@ -74,7 +74,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
     @Override
     public void setTitle(String title) {
-        Log.d(TAG, "setTitle:" + title + ".");
+        Timber.d("setTitle:" + title + ".");
         toolbar.setTitle(title);
     }
 
@@ -108,7 +108,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     @Override
     protected void onStart() {
         super.onStart();
-        Log.d(TAG, "onStart()");
+        Timber.d( "onStart()");
     }
 
     private void startWalletService() {
@@ -131,13 +131,13 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
     @Override
     protected void onStop() {
-        Log.d(TAG, "onStop()");
+        Timber.d("onStop()");
         super.onStop();
     }
 
     @Override
     protected void onDestroy() {
-        Log.d(TAG, "onDestroy()");
+        Timber.d("onDestroy()");
         stopWalletService();
         super.onDestroy();
     }
@@ -179,7 +179,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Log.d(TAG, "onCreate()");
+        Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
             // activity restarted
@@ -208,7 +208,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
                         Toast.makeText(WalletActivity.this, getString(R.string.label_donate), Toast.LENGTH_SHORT).show();
                     case Toolbar.BUTTON_NONE:
                     default:
-                        Log.e(TAG, "Button " + type + "pressed - how can this be?");
+                        Timber.e("Button " + type + "pressed - how can this be?");
                 }
             }
         });
@@ -222,11 +222,11 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
         Fragment walletFragment = new WalletFragment();
         getSupportFragmentManager().beginTransaction()
-                .add(R.id.fragment_container, walletFragment, WalletFragment.TAG).commit();
-        Log.d(TAG, "fragment added");
+                .add(R.id.fragment_container, walletFragment, WalletFragment.class.getName()).commit();
+        Timber.d("fragment added");
 
         startWalletService();
-        Log.d(TAG, "onCreate() done.");
+        Timber.d("onCreate() done.");
     }
 
     public Wallet getWallet() {
@@ -254,7 +254,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
                 }
             }
             updateProgress();
-            Log.d(TAG, "CONNECTED");
+            Timber.d( "CONNECTED");
         }
 
         public void onServiceDisconnected(ComponentName className) {
@@ -264,7 +264,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             // see this happen.
             mBoundService = null;
             setTitle(getString(R.string.wallet_activity_name), getString(R.string.status_wallet_disconnected));
-            Log.d(TAG, "DISCONNECTED");
+            Timber.d( "DISCONNECTED");
         }
     };
 
@@ -280,7 +280,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
         startService(intent);
         bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
         mIsBound = true;
-        Log.d(TAG, "BOUND");
+        Timber.d( "BOUND");
     }
 
     void disconnectWalletService() {
@@ -289,20 +289,20 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             mBoundService.setObserver(null);
             unbindService(mConnection);
             mIsBound = false;
-            Log.d(TAG, "UNBOUND");
+            Timber.d( "UNBOUND");
         }
     }
 
     @Override
     protected void onPause() {
-        Log.d(TAG, "onPause()");
+        Timber.d( "onPause()");
         super.onPause();
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d( "onResume()");
     }
 
     private PowerManager.WakeLock wl = null;
@@ -313,9 +313,9 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
         this.wl = pm.newWakeLock(PowerManager.SCREEN_DIM_WAKE_LOCK, getString(R.string.app_name));
         try {
             wl.acquire();
-            Log.d(TAG, "WakeLock acquired");
+            Timber.d( "WakeLock acquired");
         } catch (SecurityException ex) {
-            Log.w(TAG, "WakeLock NOT acquired: " + ex.getLocalizedMessage());
+            Timber.w( "WakeLock NOT acquired: %s", ex.getLocalizedMessage());
             wl = null;
         }
     }
@@ -324,7 +324,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
         if ((wl == null) || !wl.isHeld()) return;
         wl.release();
         wl = null;
-        Log.d(TAG, "WakeLock released");
+        Timber.d( "WakeLock released");
     }
 
     public void saveWallet() {
@@ -332,9 +332,9 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             Intent intent = new Intent(getApplicationContext(), WalletService.class);
             intent.putExtra(WalletService.REQUEST, WalletService.REQUEST_CMD_STORE);
             startService(intent);
-            Log.d(TAG, "STORE request sent");
+            Timber.d( "STORE request sent");
         } else {
-            Log.e(TAG, "Service not bound");
+            Timber.e( "Service not bound");
         }
     }
 
@@ -374,7 +374,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
         try {
             onRefreshed(getWallet(), true);
         } catch (IllegalStateException ex) {
-            Log.e(TAG, ex.getLocalizedMessage());
+            Timber.e( ex.getLocalizedMessage());
         }
     }
 
@@ -385,12 +385,12 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     // refresh and return if successful
     @Override
     public boolean onRefreshed(final Wallet wallet, final boolean full) {
-        Log.d(TAG, "onRefreshed()");
+        Timber.d( "onRefreshed()");
         try {
             final WalletFragment walletFragment = (WalletFragment)
-                    getSupportFragmentManager().findFragmentByTag(WalletFragment.TAG);
+                    getSupportFragmentManager().findFragmentByTag(WalletFragment.class.getName());
             if (wallet.isSynchronized()) {
-                Log.d(TAG, "onRefreshed() synced");
+                Timber.d("onRefreshed() synced");
                 releaseWakeLock(); // the idea is to stay awake until synced
                 if (!synced) { // first sync
                     onProgress(-1);
@@ -411,7 +411,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             return true;
         } catch (ClassCastException ex) {
             // not in wallet fragment (probably send monero)
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
             // keep calm and carry on
         }
         return false;
@@ -478,7 +478,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             });
         } catch (ClassCastException ex) {
             // not in spend fragment
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
             // don't need the transaction any more
             getWallet().disposePendingTransaction();
         }
@@ -513,7 +513,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             });
         } catch (ClassCastException ex) {
             // not in tx fragment
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
             // never min
         }
     }
@@ -522,7 +522,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     public void onProgress(final String text) {
         try {
             final WalletFragment walletFragment = (WalletFragment)
-                    getSupportFragmentManager().findFragmentByTag(WalletFragment.TAG);
+                    getSupportFragmentManager().findFragmentByTag(WalletFragment.class.getName());
             runOnUiThread(new Runnable() {
                 public void run() {
                     walletFragment.setProgress(text);
@@ -530,7 +530,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             });
         } catch (ClassCastException ex) {
             // not in wallet fragment (probably send monero)
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
             // keep calm and carry on
         }
     }
@@ -539,7 +539,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     public void onProgress(final int n) {
         try {
             final WalletFragment walletFragment = (WalletFragment)
-                    getSupportFragmentManager().findFragmentByTag(WalletFragment.TAG);
+                    getSupportFragmentManager().findFragmentByTag(WalletFragment.class.getName());
             runOnUiThread(new Runnable() {
                 public void run() {
                     walletFragment.setProgress(n);
@@ -547,7 +547,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             });
         } catch (ClassCastException ex) {
             // not in wallet fragment (probably send monero)
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
             // keep calm and carry on
         }
     }
@@ -571,9 +571,9 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             intent.putExtra(WalletService.REQUEST, WalletService.REQUEST_CMD_SEND);
             intent.putExtra(WalletService.REQUEST_CMD_SEND_NOTES, notes);
             startService(intent);
-            Log.d(TAG, "SEND TX request sent");
+            Timber.d("SEND TX request sent");
         } else {
-            Log.e(TAG, "Service not bound");
+            Timber.e("Service not bound");
         }
 
     }
@@ -586,9 +586,9 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             intent.putExtra(WalletService.REQUEST_CMD_SETNOTE_TX, txId);
             intent.putExtra(WalletService.REQUEST_CMD_SETNOTE_NOTES, notes);
             startService(intent);
-            Log.d(TAG, "SET NOTE request sent");
+            Timber.d("SET NOTE request sent");
         } else {
-            Log.e(TAG, "Service not bound");
+            Timber.e("Service not bound");
         }
 
     }
@@ -600,9 +600,9 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             intent.putExtra(WalletService.REQUEST, WalletService.REQUEST_CMD_TX);
             intent.putExtra(WalletService.REQUEST_CMD_TX_DATA, txData);
             startService(intent);
-            Log.d(TAG, "CREATE TX request sent");
+            Timber.d("CREATE TX request sent");
         } else {
-            Log.e(TAG, "Service not bound");
+            Timber.e("Service not bound");
         }
     }
 
@@ -665,7 +665,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
             fragment.shareTxInfo();
         } catch (ClassCastException ex) {
             // not in wallet fragment
-            Log.e(TAG, ex.getLocalizedMessage());
+            Timber.e(ex.getLocalizedMessage());
             // keep calm and carry on
         }
     }
@@ -697,7 +697,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
         if (Helper.getCameraPermission(this)) {
             startScanFragment();
         } else {
-            Log.i(TAG, "Waiting for permissions");
+            Timber.i("Waiting for permissions");
         }
 
     }
@@ -770,7 +770,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
-        Log.d(TAG, "onRequestPermissionsResult()");
+        Timber.d("onRequestPermissionsResult()");
         switch (requestCode) {
             case Helper.PERMISSIONS_REQUEST_CAMERA:
                 // If request is cancelled, the result arrays are empty.
@@ -779,7 +779,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
                     startScanFragment = true;
                 } else {
                     String msg = getString(R.string.message_camera_not_permitted);
-                    Log.e(TAG, msg);
+                    Timber.e(msg);
                     Toast.makeText(this, msg, Toast.LENGTH_LONG).show();
                 }
                 break;
@@ -793,7 +793,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
     }
 
     void startReceive(String address) {
-        Log.d(TAG, "startReceive()");
+        Timber.d( "startReceive()");
         Bundle b = new Bundle();
         b.putString("address", address);
         b.putString("name", getWalletName());
@@ -802,6 +802,6 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
     void startReceiveFragment(Bundle extras) {
         replaceFragment(new ReceiveFragment(), null, extras);
-        Log.d(TAG, "ReceiveFragment placed");
+        Timber.d( "ReceiveFragment placed");
     }
 }

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -74,7 +74,7 @@ public class WalletActivity extends SecureActivity implements WalletFragment.Lis
 
     @Override
     public void setTitle(String title) {
-        Timber.d("setTitle:" + title + ".");
+        Timber.d("setTitle:%s.", title);
         toolbar.setTitle(title);
     }
 

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
@@ -23,7 +23,6 @@ import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -52,11 +51,10 @@ import com.m2049r.xmrwallet.util.OkHttpClientSingleton;
 import java.text.NumberFormat;
 import java.util.List;
 
-import okhttp3.OkHttpClient;
+import timber.log.Timber;
 
 public class WalletFragment extends Fragment
         implements TransactionInfoAdapter.OnInteractionListener {
-    public static final String TAG = "WalletFragment";
     private TransactionInfoAdapter adapter;
     private NumberFormat formatter = NumberFormat.getInstance();
 
@@ -190,7 +188,7 @@ public class WalletFragment extends Fragment
 
                             @Override
                             public void onError(final Exception e) {
-                                Log.e(TAG, e.getLocalizedMessage());
+                                Timber.e(e.getLocalizedMessage());
                                 if (isAdded())
                                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                                         @Override
@@ -232,14 +230,14 @@ public class WalletFragment extends Fragment
     public void exchange(final ExchangeRate exchangeRate) {
         hideExchanging();
         if (!"XMR".equals(exchangeRate.getBaseCurrency())) {
-            Log.e(TAG, "Not XMR");
+            Timber.e("Not XMR");
             sCurrency.setSelection(0, true);
             balanceCurrency = "XMR";
             balanceRate = 1.0;
         } else {
             int spinnerPosition = ((ArrayAdapter) sCurrency.getAdapter()).getPosition(exchangeRate.getQuoteCurrency());
             if (spinnerPosition < 0) { // requested currency not in list
-                Log.e(TAG, "Requested currency not in list " + exchangeRate.getQuoteCurrency());
+                Timber.e("Requested currency not in list %s", exchangeRate.getQuoteCurrency());
                 sCurrency.setSelection(0, true);
             } else {
                 sCurrency.setSelection(spinnerPosition, true);
@@ -259,7 +257,7 @@ public class WalletFragment extends Fragment
     // called from activity
 
     public void onRefreshed(final Wallet wallet, final boolean full) {
-        Log.d(TAG, "onRefreshed()");
+        Timber.d("onRefreshed()");
         if (full) {
             List<TransactionInfo> list = wallet.getHistory().getAll();
             adapter.setInfos(list);
@@ -318,7 +316,7 @@ public class WalletFragment extends Fragment
         String watchOnly = (wallet.isWatchOnly() ? getString(R.string.label_watchonly) : "");
         walletSubtitle = wallet.getAddress().substring(0, 16) + "…" + watchOnly;
         activityCallback.setTitle(walletTitle, walletSubtitle);
-        Log.d(TAG, "wallet title is " + walletTitle);
+        Timber.d("wallet title is %s", walletTitle);
     }
 
     private long firstBlock = 0;
@@ -328,7 +326,7 @@ public class WalletFragment extends Fragment
 
     private void updateStatus(Wallet wallet) {
         if (!isAdded()) return;
-        Log.d(TAG, "updateStatus()");
+        Timber.d("updateStatus()");
         if (walletTitle == null) {
             setActivityTitle(wallet);
         }
@@ -413,7 +411,7 @@ public class WalletFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
-        Log.d(TAG, "onResume()");
+        Timber.d("onResume()");
         activityCallback.setTitle(walletTitle, walletSubtitle);
         activityCallback.setToolbarButton(Toolbar.BUTTON_CLOSE);
         setProgress(syncProgress);

--- a/app/src/main/java/com/m2049r/xmrwallet/XmrWalletApplication.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/XmrWalletApplication.java
@@ -1,0 +1,17 @@
+package com.m2049r.xmrwallet;
+
+
+import android.app.Application;
+
+import timber.log.Timber;
+
+public class XmrWalletApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree());
+        }
+    }
+}

--- a/app/src/main/java/com/m2049r/xmrwallet/layout/ExchangeView.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/layout/ExchangeView.java
@@ -25,7 +25,6 @@ import android.support.design.widget.TextInputLayout;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -48,10 +47,9 @@ import com.m2049r.xmrwallet.util.OkHttpClientSingleton;
 
 import java.util.Locale;
 
-import okhttp3.OkHttpClient;
+import timber.log.Timber;
 
 public class ExchangeView extends LinearLayout {
-    static final String TAG = "ExchangeView";
 
     public boolean focus() {
         return etAmount.requestFocus();
@@ -254,7 +252,7 @@ public class ExchangeView extends LinearLayout {
 
     public boolean checkEnteredAmount() {
         boolean ok = true;
-        Log.d(TAG, "checkEnteredAmount");
+        Timber.d("checkEnteredAmount");
         String amountEntry = etAmount.getEditText().getText().toString();
         if (!amountEntry.isEmpty()) {
             try {
@@ -307,7 +305,7 @@ public class ExchangeView extends LinearLayout {
 
                     @Override
                     public void onError(final Exception e) {
-                        Log.e(TAG, e.getLocalizedMessage());
+                        Timber.e(e.getLocalizedMessage());
                         new Handler(Looper.getMainLooper()).post(new Runnable() {
                             @Override
                             public void run() {
@@ -338,7 +336,7 @@ public class ExchangeView extends LinearLayout {
             }
             tvAmountB.setText(xmrAmount);
         } else { // no XMR currency - cannot happen!
-            Log.e(TAG, "No XMR currency!");
+            Timber.e("No XMR currency!");
             setXmr(null);
             notXmrAmount = null;
             return;
@@ -346,7 +344,7 @@ public class ExchangeView extends LinearLayout {
     }
 
     boolean prepareExchange() {
-        Log.d(TAG, "prepareExchange()");
+        Timber.d("prepareExchange()");
         if (checkEnteredAmount()) {
             String enteredAmount = etAmount.getEditText().getText().toString();
             if (!enteredAmount.isEmpty()) {
@@ -356,7 +354,7 @@ public class ExchangeView extends LinearLayout {
                     cleanAmount = Helper.getDisplayAmount(Wallet.getAmountFromString(enteredAmount));
                     setXmr(cleanAmount);
                     notXmrAmount = null;
-                    Log.d(TAG, "cleanAmount = " + cleanAmount);
+                    Timber.d("cleanAmount = %s", cleanAmount);
                 } else if (getCurrencyB() == 0) { // we use B & 0 here for the else below ...
                     // sanitize the input
                     double amountA = Double.parseDouble(enteredAmount);
@@ -364,12 +362,12 @@ public class ExchangeView extends LinearLayout {
                     setXmr(null);
                     notXmrAmount = cleanAmount;
                 } else { // no XMR currency - cannot happen!
-                    Log.e(TAG, "No XMR currency!");
+                    Timber.e("No XMR currency!");
                     setXmr(null);
                     notXmrAmount = null;
                     return false;
                 }
-                Log.d(TAG, "prepareExchange() " + cleanAmount);
+                Timber.d("prepareExchange() %s", cleanAmount);
                 //etAmount.getEditText().setText(cleanAmount); // display what we use
             } else {
                 setXmr("");
@@ -399,7 +397,7 @@ public class ExchangeView extends LinearLayout {
         if (!exchangeRate.getBaseCurrency().equals(enteredCurrencyA)
                 || !exchangeRate.getQuoteCurrency().equals(enteredCurrencyB)) {
             // something's wrong
-            Log.e(TAG, "Currencies don't match!");
+            Timber.e("Currencies don't match!");
             return;
         }
         if (prepareExchange()) {

--- a/app/src/main/java/com/m2049r/xmrwallet/layout/TransactionInfoAdapter.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/layout/TransactionInfoAdapter.java
@@ -19,7 +19,6 @@ package com.m2049r.xmrwallet.layout;
 import android.content.Context;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,8 +36,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import timber.log.Timber;
+
 public class TransactionInfoAdapter extends RecyclerView.Adapter<TransactionInfoAdapter.ViewHolder> {
-    private static final String TAG = "TransactionInfoAdapter";
 
     private final SimpleDateFormat DATETIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 
@@ -96,11 +96,11 @@ public class TransactionInfoAdapter extends RecyclerView.Adapter<TransactionInfo
         // as the TransactionInfo items are always recreated, we cannot recycle
         this.infoItems.clear();
         if (data != null) {
-            Log.d(TAG, "setInfos " + data.size());
+            Timber.d("setInfos %s", data.size());
             infoItems.addAll(data);
             Collections.sort(infoItems);
         } else {
-            Log.d(TAG, "setInfos null");
+            Timber.d("setInfos null");
         }
         notifyDataSetChanged();
     }

--- a/app/src/main/java/com/m2049r/xmrwallet/layout/WalletInfoAdapter.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/layout/WalletInfoAdapter.java
@@ -19,7 +19,6 @@ package com.m2049r.xmrwallet.layout;
 import android.content.Context;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -38,8 +37,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import timber.log.Timber;
+
 public class WalletInfoAdapter extends RecyclerView.Adapter<WalletInfoAdapter.ViewHolder> {
-    private static final String TAG = "WalletInfoAdapter";
 
     private final SimpleDateFormat DATETIME_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 
@@ -89,11 +89,11 @@ public class WalletInfoAdapter extends RecyclerView.Adapter<WalletInfoAdapter.Vi
         // as the WalletInfo items are always recreated, we cannot recycle
         infoItems.clear();
         if (data != null) {
-            Log.d(TAG, "setInfos " + data.size());
+            Timber.d("setInfos %s", data.size());
             infoItems.addAll(data);
             Collections.sort(infoItems);
         } else {
-            Log.d(TAG, "setInfos null");
+            Timber.d("setInfos null");
         }
         notifyDataSetChanged();
     }

--- a/app/src/main/java/com/m2049r/xmrwallet/model/WalletManager.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/WalletManager.java
@@ -16,21 +16,17 @@
 
 package com.m2049r.xmrwallet.model;
 
-import android.support.annotation.NonNull;
-import android.util.Log;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+
+import timber.log.Timber;
 
 public class WalletManager {
-    private final static String TAG = "WalletManager";
 
     static {
         System.loadLibrary("monerujo");
@@ -54,7 +50,7 @@ public class WalletManager {
     }
 
     private void manageWallet(Wallet wallet) {
-        Log.d(TAG, "Managing " + wallet.getName());
+        Timber.d("Managing %s", wallet.getName());
         managedWallet = wallet;
     }
 
@@ -68,7 +64,7 @@ public class WalletManager {
         if (getWallet() != wallet) {
             throw new IllegalStateException(wallet.getName() + " not under management!");
         }
-        Log.d(TAG, "Unmanaging " + managedWallet.getName());
+        Timber.d("Unmanaging %s", managedWallet.getName());
         managedWallet = null;
     }
 
@@ -165,14 +161,14 @@ public class WalletManager {
         info.path = wallet.getParentFile();
         info.name = wallet.getName();
         File addressFile = new File(info.path, info.name + ".address.txt");
-        //Log.d(TAG, addressFile.getAbsolutePath());
+        //Timber.d(addressFile.getAbsolutePath());
         info.address = "??????";
         BufferedReader addressReader = null;
         try {
             addressReader = new BufferedReader(new FileReader(addressFile));
             info.address = addressReader.readLine();
         } catch (IOException ex) {
-            Log.d(TAG, ex.getLocalizedMessage());
+            Timber.d(ex.getLocalizedMessage());
         } finally {
             if (addressReader != null) {
                 try {
@@ -187,7 +183,7 @@ public class WalletManager {
 
     public List<WalletInfo> findWallets(File path) {
         List<WalletInfo> wallets = new ArrayList<>();
-        Log.d(TAG, "Scanning: " + path.getAbsolutePath());
+        Timber.d("Scanning: %s", path.getAbsolutePath());
         File[] found = path.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String filename) {
                 return filename.endsWith(".keys");
@@ -217,7 +213,7 @@ public class WalletManager {
     }
 
     public void setDaemon(String address, boolean testnet, String username, String password) {
-        //Log.d(TAG, "SETDAEMON " + username + "/" + password + "/" + address);
+        //Timber.d("SETDAEMON " + username + "/" + password + "/" + address);
         this.daemonAddress = address;
         this.testnet = testnet;
         this.daemonUsername = username;

--- a/app/src/main/java/com/m2049r/xmrwallet/service/WalletService.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/service/WalletService.java
@@ -92,15 +92,15 @@ public class WalletService extends Service {
 
         // WalletListener callbacks
         public void moneySpent(String txId, long amount) {
-            Timber.d("moneySpent() " + amount + " @ " + txId);
+            Timber.d("moneySpent() %d @ %s", amount, txId);
         }
 
         public void moneyReceived(String txId, long amount) {
-            Timber.d("moneyReceived() " + amount + " @ " + txId);
+            Timber.d("moneyReceived() %d @ %s",amount, txId);
         }
 
         public void unconfirmedMoneyReceived(String txId, long amount) {
-            Timber.d("unconfirmedMoneyReceived() " + amount + " @ " + txId);
+            Timber.d("unconfirmedMoneyReceived() %d @ %s", amount, txId);
         }
 
         long lastBlockTime = 0;
@@ -111,7 +111,7 @@ public class WalletService extends Service {
             if (wallet == null) throw new IllegalStateException("No wallet!");
             // don't flood with an update for every block ...
             if (lastBlockTime < System.currentTimeMillis() - 2000) {
-                Timber.d("newBlock() @" + height + " with observer " + observer);
+                Timber.d("newBlock() @ %d with observer %s", height, observer);
                 lastBlockTime = System.currentTimeMillis();
                 if (observer != null) {
                     boolean fullRefresh = false;
@@ -294,7 +294,7 @@ public class WalletService extends Service {
                         Wallet myWallet = getWallet();
                         Timber.d("STORE wallet: %s", myWallet.getName());
                         boolean rc = myWallet.store();
-                        Timber.d("wallet stored: " + myWallet.getName() + " with rc=" + rc);
+                        Timber.d("wallet stored: %s with rc=%b", myWallet.getName(), rc);
                         if (!rc) {
                             Timber.w("Wallet store failed: %s", myWallet.getErrorString());
                         }
@@ -350,7 +350,7 @@ public class WalletService extends Service {
                                 myWallet.setUserNote(txid, notes);
                             }
                             boolean rc = myWallet.store();
-                            Timber.d("wallet stored: " + myWallet.getName() + " with rc=" + rc);
+                            Timber.d("wallet stored: %s with rc=%b", myWallet.getName(), rc);
                             if (!rc) {
                                 Timber.w("Wallet store failed: %s", myWallet.getErrorString());
                             }
@@ -370,7 +370,7 @@ public class WalletService extends Service {
                             if (observer != null) observer.onSetNotes(success);
                             if (success) {
                                 boolean rc = myWallet.store();
-                                Timber.d("wallet stored: " + myWallet.getName() + " with rc=" + rc);
+                                Timber.d("wallet stored: %s with rc=%b", myWallet.getName(), rc);
                                 if (!rc) {
                                     Timber.w("Wallet store failed: %s", myWallet.getErrorString());
                                 }

--- a/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
@@ -113,7 +113,7 @@ public class Helper {
     static public File getWalletFile(Context context, String aWalletName) {
         File walletDir = getStorageRoot(context);
         File f = new File(walletDir, aWalletName);
-        Timber.d("wallet = " + f.getAbsolutePath() + " size=" + f.length());
+        Timber.d("wallet= %s size= %d", f.getAbsolutePath(), f.length());
         return f;
     }
 

--- a/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
@@ -31,7 +31,6 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
 import android.os.Environment;
 import android.support.v4.content.ContextCompat;
-import android.util.Log;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 
@@ -48,10 +47,9 @@ import java.util.Locale;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import okhttp3.OkHttpClient;
+import timber.log.Timber;
 
 public class Helper {
-    static private final String TAG = "Helper";
     static private final String WALLET_DIR = "monerujo";
 
     static public int DISPLAY_DIGITS_INFO = 5;
@@ -60,17 +58,17 @@ public class Helper {
     static public File getStorageRoot(Context context) {
         if (!isExternalStorageWritable()) {
             String msg = context.getString(R.string.message_strorage_not_writable);
-            Log.e(TAG, msg);
+            Timber.e(msg);
             throw new IllegalStateException(msg);
         }
         File dir = new File(Environment.getExternalStorageDirectory(), WALLET_DIR);
         if (!dir.exists()) {
-            Log.i(TAG, "Creating " + dir.getAbsolutePath());
+            Timber.i("Creating %s", dir.getAbsolutePath());
             dir.mkdirs(); // try to make it
         }
         if (!dir.isDirectory()) {
             String msg = "Directory " + dir.getAbsolutePath() + " does not exist.";
-            Log.e(TAG, msg);
+            Timber.e(msg);
             throw new IllegalStateException(msg);
         }
         return dir;
@@ -82,7 +80,7 @@ public class Helper {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             if (context.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                     == PackageManager.PERMISSION_DENIED) {
-                Log.w(TAG, "Permission denied to WRITE_EXTERNAL_STORAGE - requesting it");
+                Timber.w("Permission denied to WRITE_EXTERNAL_STORAGE - requesting it");
                 String[] permissions = {Manifest.permission.WRITE_EXTERNAL_STORAGE};
                 context.requestPermissions(permissions, PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
                 return false;
@@ -100,7 +98,7 @@ public class Helper {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             if (context.checkSelfPermission(Manifest.permission.CAMERA)
                     == PackageManager.PERMISSION_DENIED) {
-                Log.w(TAG, "Permission denied for CAMERA - requesting it");
+                Timber.w("Permission denied for CAMERA - requesting it");
                 String[] permissions = {Manifest.permission.CAMERA};
                 context.requestPermissions(permissions, PERMISSIONS_REQUEST_CAMERA);
                 return false;
@@ -115,7 +113,7 @@ public class Helper {
     static public File getWalletFile(Context context, String aWalletName) {
         File walletDir = getStorageRoot(context);
         File f = new File(walletDir, aWalletName);
-        Log.d(TAG, "wallet = " + f.getAbsolutePath() + " size=" + f.length());
+        Timber.d("wallet = " + f.getAbsolutePath() + " size=" + f.length());
         return f;
     }
 
@@ -224,11 +222,11 @@ public class Helper {
             }
             return sb.toString();
         } catch (SocketTimeoutException ex) {
-            Log.w(TAG, "C " + ex.getLocalizedMessage());
+            Timber.w("C %s", ex.getLocalizedMessage());
         } catch (MalformedURLException ex) {
-            Log.e(TAG, "A " + ex.getLocalizedMessage());
+            Timber.e("A %s", ex.getLocalizedMessage());
         } catch (IOException ex) {
-            Log.e(TAG, "B " + ex.getLocalizedMessage());
+            Timber.e("B %s", ex.getLocalizedMessage());
         } finally {
             if (urlConnection != null) {
                 urlConnection.disconnect();

--- a/app/src/main/java/com/m2049r/xmrwallet/util/NodeList.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/NodeList.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class NodeList {
-    static private final String TAG = "NodeList";
     private static final int MAX_SIZE = 5;
 
     private List<String> nodes = new ArrayList<>();

--- a/app/src/main/res/values/about.xml
+++ b/app/src/main/res/values/about.xml
@@ -93,6 +93,9 @@
         <h3>OkHttp</h3>
         Copyright (c) 2014 Square, Inc.
 
+        <h3>Timber</h3>
+        Copyright (c) 2013 Jake Wharton
+
         <h3>com.google.zxing:core</h3>
         Copyright (c) 2012 ZXing authors
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,4 +30,5 @@ ext {
     okHttpVersion = '3.9.0'
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'
+    timberVersion = '4.6.0'
 }


### PR DESCRIPTION
Since Proguard is disabled for the release build all log calls are shown when the app is executed. Do `adb shell logcat | grep xmrwallet` to see them. This is not good, no log information should be enabled for the release build, only for debug builds. (Or even worse as it is stated in the Timber Readme: "…every time you log in production, a puppy dies.") 
I added Timber that makes logging easy and later can be extended when we add crash reporting. And of course now nothing is logged in production.
