### PR TITLE
APK Split

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,15 @@ android {
             path "CMakeLists.txt"
         }
     }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include "armeabi-v7a"
+            universalApk false
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Since #172 will introduce new possible architectures it makes sense to split the generated APKs. With this PR gradle generates different APKs that only include the specified ABIs. Therefore the final APK is not that big and the user only has to download the needed version(Play store is taking care of this)