### PR TITLE
Background borderless for nicer ripple effect in numpad

### DIFF
--- a/app/src/main/res/layout/view_number_pad.xml
+++ b/app/src/main/res/layout/view_number_pad.xml
@@ -18,8 +18,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="1"
             android:text="1" />
 
@@ -29,8 +27,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="2"
             android:text="2" />
 
@@ -40,8 +36,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="3"
             android:text="3" />
     </LinearLayout>
@@ -50,7 +44,6 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-
         android:gravity="center">
 
         <TextView
@@ -59,8 +52,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="4"
             android:text="4" />
 
@@ -70,8 +61,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="5"
             android:text="5" />
 
@@ -81,8 +70,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="6"
             android:text="6" />
     </LinearLayout>
@@ -99,8 +86,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="7"
             android:text="7" />
 
@@ -110,8 +95,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="8"
             android:text="8" />
 
@@ -121,8 +104,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="9"
             android:text="9" />
     </LinearLayout>
@@ -139,8 +120,6 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:text="." />
 
         <TextView
@@ -149,8 +128,6 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
             android:tag="0"
             android:text="0" />
 
@@ -160,7 +137,7 @@
             android:layout_height="36sp"
             android:layout_gravity="center"
             android:layout_weight="1"
-            android:background="?android:attr/selectableItemBackground"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
             android:src="@drawable/ic_backspace_black_36dp" />
     </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -119,6 +119,8 @@
     <style name="MoneroLabel.NumPad">
         <item name="android:textSize">36sp</item>
         <item name="android:textColor">@color/moneroBlack</item>
+        <item name="android:background">?android:attr/selectableItemBackgroundBorderless</item>
+        <item name="android:gravity">center</item>
     </style>
 
     <style name="MoneroLabel.Title">


### PR DESCRIPTION
Refactored the numpad layout a little bit and used background borderless for a nicer ripple effect.
![hammerheadm4b30zstephan01222018202620](https://user-images.githubusercontent.com/434214/35240134-c1c56810-ffb2-11e7-84e9-d64844431f9f.gif)
