### PR TITLE
Change gender-specific word

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,7 +145,7 @@
     <string name="status_transaction_failed">Transaction failed: %1$s</string>
     <string name="status_transaction_prepare_failed">Could not create transaction!</string>
 
-    <string name="send_xmrto_timeout">Dude, you waited too long!</string>
+    <string name="send_xmrto_timeout">You waited too long my friend!</string>
 
     <string name="service_busy">I am still busy with your last wallet &#8230;</string>
 


### PR DESCRIPTION
From `Dude` to `Mate`. If you don't like "mate" (it's mostly used in Europe and Australia AFAIK) we can use something else, but i think any gender-specific terminology should be avoided