### PR TITLE
Fix "restore from seed" too long on certain devices

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -310,8 +310,8 @@
 
     <string name="fab_create_new">Créer un nouveau portefeuille</string>
     <string name="fab_restore_viewonly">Restaurer un portefeuille d\'audit</string>
-    <string name="fab_restore_key">Restaurer un portefeuille depuis la clef privée</string>
-    <string name="fab_restore_seed">Restaurer un portefeuille depuis la phrase mnémonique</string>
+    <string name="fab_restore_key">Restaurer depuis la clef privée</string>
+    <string name="fab_restore_seed">Restaurer depuis la phrase mnémonique</string>
 
     <string name="accounts_drawer_new">Créer un Compte</string>
     <string name="accounts_drawer_title">Comptes</string>


### PR DESCRIPTION
This solves #342

Sorry @erciccione i didn't catch that on my S6 edge plus device. I guess my screen was too big to face it.

So i corrected it as sugested by @m2049r himself in monerujo-io/aeonwallet#7
I also changed the "restore from key" accordingly, for consistency and to avoid the same problem on smaller screen (thinking wide adoption here). I kept the "restore audit wallet" as is however, because it's the first restoration method and will help to understand the two below.