### PR TITLE
Improve method of enumerating available locales

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,16 +46,16 @@ android {
     def abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2, 'x86': 3, 'x86_64': 4]
 
     // Enumerate translated locales
-    def translatedLocales = []
+    def availableLocales = ["en"]
     new File("app/src/main/res/").eachFileMatch(~/^values-.*/) { file ->
         def languageTag = file.name.substring(7).replace("-r", "-")
-        translatedLocales.add(languageTag)
+        availableLocales.add(languageTag)
     }
 
     // APKs for the same app that all have the same version information.
     android.applicationVariants.all { variant ->
-        // Update string resource: translated_locales
-        variant.resValue("string", "translated_locales", translatedLocales.join(","))
+        // Update string resource: available_locales
+        variant.resValue("string", "available_locales", availableLocales.join(","))
         // Assigns a different version code for each output APK.
         variant.outputs.all {
             output ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,17 @@ android {
     // Map for the version code that gives each ABI a value.
     def abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2, 'x86': 3, 'x86_64': 4]
 
+    // Enumerate translated locales
+    def translatedLocales = ["en"]
+    new File("app/src/main/res/").eachFileMatch(~/^values-.*/) { file ->
+        def languageTag = file.name.substring(7).replace("-r", "-")
+        translatedLocales.add(languageTag)
+    }
+
     // APKs for the same app that all have the same version information.
     android.applicationVariants.all { variant ->
+        // Update string resource: translated_locales
+        variant.resValue("string", "translated_locales", translatedLocales.join(","))
         // Assigns a different version code for each output APK.
         variant.outputs.all {
             output ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
     def abiCodes = ['armeabi-v7a': 1, 'arm64-v8a': 2, 'x86': 3, 'x86_64': 4]
 
     // Enumerate translated locales
-    def translatedLocales = ["en"]
+    def translatedLocales = []
     new File("app/src/main/res/").eachFileMatch(~/^values-.*/) { file ->
         def languageTag = file.name.substring(7).replace("-r", "-")
         translatedLocales.add(languageTag)

--- a/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
@@ -966,10 +966,10 @@ public class LoginActivity extends SecureActivity
     }
 
     public void onChangeLocale() {
-        final ArrayList<Locale> translatedLocales = LocaleHelper.getAvailableLocales(LoginActivity.this);
-        String[] localeDisplayName = new String[1 + translatedLocales.size()];
+        final ArrayList<Locale> availableLocales = LocaleHelper.getAvailableLocales(LoginActivity.this);
+        String[] localeDisplayName = new String[1 + availableLocales.size()];
 
-        Collections.sort(translatedLocales, new Comparator<Locale>() {
+        Collections.sort(availableLocales, new Comparator<Locale>() {
             @Override
             public int compare(Locale locale1, Locale locale2) {
                 String localeString1 = LocaleHelper.getDisplayName(locale1, true);
@@ -980,7 +980,7 @@ public class LoginActivity extends SecureActivity
 
         localeDisplayName[0] = getString(R.string.language_system_default);
         for (int i = 1; i < localeDisplayName.length; i++) {
-            Locale locale = translatedLocales.get(i - 1);
+            Locale locale = availableLocales.get(i - 1);
             localeDisplayName[i] = LocaleHelper.getDisplayName(locale, true);
         }
 
@@ -1000,7 +1000,7 @@ public class LoginActivity extends SecureActivity
                 dialog.dismiss();
 
                 LocaleHelper.setLocale(LoginActivity.this,
-                        (i == 0) ? "" : translatedLocales.get(i - 1).toLanguageTag());
+                        (i == 0) ? "" : availableLocales.get(i - 1).toLanguageTag());
                 startActivity(getIntent().addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
             }
         });

--- a/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/LoginActivity.java
@@ -972,8 +972,8 @@ public class LoginActivity extends SecureActivity
         Collections.sort(translatedLocales, new Comparator<Locale>() {
             @Override
             public int compare(Locale locale1, Locale locale2) {
-                String localeString1 = LocaleHelper.getLocaleString(LoginActivity.this, locale1, LocaleHelper.COMPARED_RESOURCE_ID);
-                String localeString2 = LocaleHelper.getLocaleString(LoginActivity.this, locale2, LocaleHelper.COMPARED_RESOURCE_ID);
+                String localeString1 = LocaleHelper.getDisplayName(locale1, true);
+                String localeString2 = LocaleHelper.getDisplayName(locale2, true);
                 return localeString1.compareTo(localeString2);
             }
         });
@@ -981,14 +981,14 @@ public class LoginActivity extends SecureActivity
         localeDisplayName[0] = getString(R.string.language_system_default);
         for (int i = 1; i < localeDisplayName.length; i++) {
             Locale locale = translatedLocales.get(i - 1);
-            localeDisplayName[i] = LocaleHelper.getLocaleString(LoginActivity.this, locale, LocaleHelper.COMPARED_RESOURCE_ID);
+            localeDisplayName[i] = LocaleHelper.getDisplayName(locale, true);
         }
 
         int currentLocaleIndex = 0;
         String currentLocaleName = LocaleHelper.getLocale(LoginActivity.this);
         if (!currentLocaleName.isEmpty()) {
             Locale currentLocale = Locale.forLanguageTag(currentLocaleName);
-            String currentLocalizedString = LocaleHelper.getLocaleString(LoginActivity.this, currentLocale, LocaleHelper.COMPARED_RESOURCE_ID);
+            String currentLocalizedString = LocaleHelper.getDisplayName(currentLocale, true);
             currentLocaleIndex = Arrays.asList(localeDisplayName).indexOf(currentLocalizedString);
         }
 

--- a/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
@@ -19,6 +19,8 @@ public class LocaleHelper {
         ArrayList<Locale> locales = new ArrayList<>();
         String[] translatedLocales = context.getString(R.string.translated_locales).split(",");
 
+        locales.add(Locale.ENGLISH);
+
         for (String localeName : translatedLocales) {
             locales.add(Locale.forLanguageTag(localeName));
         }

--- a/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
@@ -17,11 +17,9 @@ public class LocaleHelper {
 
     public static ArrayList<Locale> getAvailableLocales(Context context) {
         ArrayList<Locale> locales = new ArrayList<>();
-        String[] translatedLocales = context.getString(R.string.translated_locales).split(",");
+        String[] availableLocales = context.getString(R.string.available_locales).split(",");
 
-        locales.add(Locale.ENGLISH);
-
-        for (String localeName : translatedLocales) {
+        for (String localeName : availableLocales) {
             locales.add(Locale.forLanguageTag(localeName));
         }
 

--- a/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/LocaleHelper.java
@@ -12,25 +12,28 @@ import java.util.HashSet;
 import java.util.Locale;
 
 public class LocaleHelper {
-    public static final int COMPARED_RESOURCE_ID = R.string.language;
-
     private static final String PREFERRED_LOCALE_KEY = "preferred_locale";
     private static Locale SYSTEM_DEFAULT_LOCALE = Locale.getDefault();
 
     public static ArrayList<Locale> getAvailableLocales(Context context) {
         ArrayList<Locale> locales = new ArrayList<>();
-        HashSet<String> localizedStrings = new HashSet<>();
+        String[] translatedLocales = context.getString(R.string.translated_locales).split(",");
 
-        for (String localeName : context.getAssets().getLocales()) {
-            Locale locale = Locale.forLanguageTag(localeName);
-            String localizedString = getLocaleString(context, locale, COMPARED_RESOURCE_ID);
-
-            if (localizedStrings.add(localizedString)) {
-                locales.add(locale);
-            }
+        for (String localeName : translatedLocales) {
+            locales.add(Locale.forLanguageTag(localeName));
         }
 
         return locales;
+    }
+
+    public static String getDisplayName(Locale locale, boolean sentenceCase) {
+        String displayName = locale.getDisplayName(locale);
+
+        if (sentenceCase) {
+            displayName = toSentenceCase(displayName, locale);
+        }
+
+        return displayName;
     }
 
     public static String getLocale(Context context) {
@@ -55,10 +58,14 @@ public class LocaleHelper {
         SYSTEM_DEFAULT_LOCALE = locale;
     }
 
-    public static String getLocaleString(Context context, Locale locale, int resId) {
-        Configuration configuration = context.getResources().getConfiguration();
-        configuration.setLocale(locale);
-        return context.createConfigurationContext(configuration).getString(resId);
+    private static String toSentenceCase(String str, Locale locale) {
+        if (str.isEmpty()) {
+            return str;
+        }
+
+        int firstCodePointLen = str.offsetByCodePoints(0, 1);
+        return str.substring(0, firstCodePointLen).toUpperCase(locale)
+                + str.substring(firstCodePointLen);
     }
 
     private static String getPreferredLocale(Context context) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -319,7 +319,6 @@
     <string name="tx_subaddress">Subadresse #%1$d</string>
     <string name="generate_address_label_sub">Öffentliche Subadresse #%1$d</string>
 
-    <string name="language">Deutsch</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -318,7 +318,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Ελληνικά</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -304,7 +304,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Español</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -322,7 +322,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Français</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -320,7 +320,6 @@
     <string name="tx_subaddress">Alcím #%1$d</string>
     <string name="generate_address_label_sub">Nyilvános alcím #%1$d</string>
 
-    <string name="language">Magyar</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -320,7 +320,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Subaddress pubblico #%1$d</string>
 
-    <string name="language">Italiano</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -318,7 +318,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Norsk bokmål</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -322,7 +322,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Português</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -318,7 +318,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Română</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -321,7 +321,6 @@
     <string name="tx_subaddress">Субадрес #%1$d</string>
     <string name="generate_address_label_sub">Публичный субадрес #%1$d</string>
 
-    <string name="language">Русский</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -303,7 +303,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">Svenska</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -316,7 +316,6 @@
     <string name="tx_subaddress">附属地址 #%1$d</string>
     <string name="generate_address_label_sub">附属公开地址 #%1$d</string>
 
-    <string name="language">中文（中国）</string>
     <string name="menu_language">语言</string>
     <string name="language_system_default">使用系统语言</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -317,7 +317,6 @@
     <string name="tx_subaddress">子地址 #%1$d</string>
     <string name="generate_address_label_sub">公開子地址 #%1$d</string>
 
-    <string name="language">中文（台灣）</string>
     <string name="menu_language">語言</string>
     <string name="language_system_default">使用系統語言</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,7 +366,6 @@
     <string name="tx_subaddress">Subaddress #%1$d</string>
     <string name="generate_address_label_sub">Public Subaddress #%1$d</string>
 
-    <string name="language">English</string>
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 </resources>


### PR DESCRIPTION
* Enumerate translated locales using Gradle script to fix bug mentioned [here](https://github.com/m2049r/xmrwallet/pull/344#issuecomment-409684941)
* Capitalize the first letter returned by ```Locale.getDisplayName()```
* Remove ```R.string.language```