### PR TITLE
Dutch translation

### DIFF
--- a/app/src/main/res/values-nl/about.xml
+++ b/app/src/main/res/values-nl/about.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="about_close">Sluiten</string>
+    <string name="about_whoami">Ik ben monerujo</string>
+    <string name="about_version">Versie %1$s (%2$d)</string>
+
+    <string name="credits_text"><![CDATA[
+        <b>Makers</b>
+        <br/>
+        m2049r, baltsar777, anhdres, keejef,
+        rehrar, EarlOfEgo e.a.
+        <br/><br/>
+        <a href="https://monerujo.io/">monerujo.io</a>
+        ]]></string>
+
+    <string name="privacy_policy"><![CDATA[
+        <h1>Privacybeleid</h1>
+        <p>Deze pagina geeft informatie over ons beleid met betrekking tot het verzamelen, gebruiken en openbaar maken van persoonlijke gegevens die we ontvangen van gebruikers van onze app (monerujo: Monero-portemonnee).
+        </p>
+        <p>Door deze app te gebruiken ga je akkoord met het verzamelen en gebruiken van gegevens volgens dit beleid.
+        </p>
+        <h2>Verzamelde gegevens</h2>
+        <p>Persoonlijke gegevens zijn alle gegevens waarmee iemand kan worden geïdentificeerd.
+        </p>
+        <p>Monero-sleutels en openbare Monero-adressen worden lokaal verzameld en verwerkt door de app, om transacties in versleutelde vorm te kunnen verwerken en verzenden op het Monero-netwerk.
+        </p>
+        <p>Verder worden er geen persoonlijke gegevens verzameld door de app.</p>
+        <p>Als je de optionele wisselkoersfunctie gebruikt, haalt monerujo de wisselkoers op via de openbare API van coinmarketcap.com.
+        Zie het privacybeleid op https://coinmarketcap.com/privacy voor meer informatie over hoe de gegevens in je aanvragen worden verzameld.</p>
+        <p>Als je de app gebruikt om naar BTC-adressen te betalen, maak je gebruik van de service XMR.TO.
+        Zie hun privacybeleid op https://xmr.to/ voor meer informatie. Monerujo verzendt het BTC-adres en -bedrag van de bestemming naar XMR.TO. Je IP-adres kan ook worden bewaard.</p>
+        <h2>App-machtigingen</h2>
+        <ul>
+        <li>INTERNET: Verbinding maken met het Monero-netwerk via een Monero-node</li>
+        <li>READ_EXTERNAL_STORAGE: Portemonneebestanden lezen die zijn opgeslagen op het apparaat</li>
+        <li>WRITE_EXTERNAL_STORAGE: Schrijven naar portemonneebestanden die zijn opgeslagen op het apparaat</li>
+        <li>WAKE_LOCK: Apparaat actief houden tijdens het synchroniseren</li>
+        <li>CAMERA: QR-codes scannen om Monero te ontvangen</li>
+        </ul>
+        <h2>Wijzigingen van dit Privacybeleid</h2>
+        <p>Dit Privacybeleid kan van tijd tot tijd worden bijgewerkt. We kondigen wijzigingen aan door het nieuwe Privacybeleid te publiceren in de app en op de website www.monerujo.io. We raden je aan om af en toe te controleren of dit Privacybeleid is gewijzigd.
+        <p>Laatste wijziging van dit Privacybeleid: 10 november 2017.
+        </p>
+        <h2>Contact</h2>
+        <p>Als je vragen hebt over ons Privacybeleid, of over hoe je gegevens worden verzameld en verwerkt, kun je een e-mail naar privacy@monerujo.io sturen (in het Engels).
+        </p>
+        ]]></string>
+  
+</resources>

--- a/app/src/main/res/values-nl/help.xml
+++ b/app/src/main/res/values-nl/help.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="help_create_new"><![CDATA[
+        <h1>Portemonnee maken - Nieuw</h1>
+        <p>Als je een nieuw Monero-adres nodig hebt.</p>
+        <p>Voer een unieke naam en wachtwoord in.
+        Met het wachtwoord worden de gegevens in je portemonnee op dit apparaat beveiligd. Gebruik een sterk wachtwoord - of liever een wachtzin van meerdere woorden.</p>
+        <h2>Schrijf je hersteltekst op!</h2>
+        <p>Op het volgende scherm wordt de hersteltekst (\"mnemonic seed\") van 25 woorden getoond.
+        Dit is het enige dat je nodig hebt om later je portemonnee te herstellen en volledige toegang tot je geld te krijgen.
+        Het is belangrijk om deze gegevens verborgen te houden, want hiermee kan <em>iedereen</em> volledige toegang tot je portemonnee krijgen, met alle gevolgen van dien.</p>
+        <p>Als je het wachtwoord van je portemonnee kwijtraakt, kun je nog steeds je portemonnee herstellen met de hersteltekst.</p>
+        <p>Maar het is niet mogelijk om je hersteltekst terug te vinden als je deze kwijtraakt. Dan ben je ook je geld kwijt!
+        Je kunt de hersteltekst niet veranderen. Als de hersteltekst wordt gestolen of niet langer geheim is, moet je je geld overmaken naar een nieuwe portemonnee (met een nieuwe hersteltekst). Daarom is het het beste dat je back-ups van je hersteltekst maakt door de 25 woorden op te schrijven en op <em>meerdere</em> veilige plekken op te slaan.</p>
+    ]]></string>
+
+    <string name="help_create_seed"><![CDATA[
+        <h1>Portemonnee maken - Hersteltekst</h1>
+        <p>Als je al een Monero-adres hebt en de transacties wilt ophalen vanuit de blockchain.</p>
+        <p>Voer een unieke naam en wachtwoord in. Met het wachtwoord worden de gegevens in je portemonnee op dit apparaat beveiligd.
+        Gebruik een sterk wachtwoord - of liever een wachtzin van meerdere woorden.</p>
+        <p>Voer je hersteltekst in het veld \"Hersteltekst\" in.<p>
+        <p>Voer in het veld \"Herstelpunt\" het bloknummer in van de eerste transactie die voor dit adres is gebruikt. Je kunt ook een datum gebruiken, met de indeling JJJJ-MM-DD. Als je het niet zeker weet, kun je een schatting invoeren van de datum/blokhoogte <em>voordat</em> je het adres van deze portemonnee voor het eerst hebt gebruikt.</p>
+    ]]></string>
+
+    <string name="help_create_ledger"><![CDATA[
+        <h1>Portemonnee maken - Ledger</h1>
+        <p>Je wilt de portemonnee gebruiken die op je Ledger Nano S staat.</p>
+        <p>Je geheime sleutel wordt nooit opgehaald van je Ledger, dus je moet het apparaat iedere keer aansluiten als je deze portemonnee wilt gebruiken.</p>
+        <p>Voer een unieke naam en wachtwoord in. Met het wachtwoord worden de gegevens in je portemonnee op je Android-apparaat beveiligd. Gebruik een sterk wachtwoord - of liever een wachtzin van meerdere woorden.</p>
+        <p>Voer in het veld \"Herstelpunt\" het bloknummer in van de eerste transactie die voor dit adres is gebruikt. Je kunt ook een datum gebruiken, met de indeling JJJJ-MM-DD. Als je het niet zeker weet, kun je een schatting invoeren van de datum/blokhoogte <em>voordat</em> je het adres van deze portemonnee voor het eerst hebt gebruikt.</p>
+    ]]></string>
+
+    <string name="help_create_keys"><![CDATA[
+        <h1>Portemonnee maken - Sleutels</h1>
+        <p>Als je een Monero-adres herstelt met je sleutels.</p>
+        <p>Voer een unieke naam en wachtwoord in. Met het wachtwoord worden de gegevens in je portemonnee op dit apparaat beveiligd.
+        Gebruik een sterk wachtwoord - of liever een wachtzin van meerdere woorden.</p>
+        <p>Voer je Monero-adres in het veld \"Openbaar adres\" in, en vul de velden \"Alleen-lezen sleutel\" en \"Bestedingssleutel\" in.<p>
+        <p>Voer in het veld \"Herstelpunt\" het bloknummer in van de eerste transactie die voor dit adres is gebruikt. Je kunt ook een datum gebruiken, met de indeling JJJJ-MM-DD. Als je het niet zeker weet, kun je een schatting invoeren van de datum/blokhoogte <em>voordat</em> je het adres van deze portemonnee voor het eerst hebt gebruikt.</p>
+    ]]></string>
+
+    <string name="help_create_view"><![CDATA[
+        <h1>Portemonnee maken - Alleen-lezen</h1>
+        <p>Als je alleen de binnenkomende transacties voor een portemonnee wilt bekijken.</p>
+        <p>Voer een unieke naam en wachtwoord in. Met het wachtwoord worden de gegevens in je portemonnee op dit apparaat beveiligd.
+        Gebruik een sterk wachtwoord - of liever een wachtzin van meerdere woorden.</p>
+        <p>Voer je Monero-adres in het veld \"Openbaar adres\" in, en vul het veld \"Alleen-lezen sleutel\" in.<p>
+        <p>Voer in het veld \"Herstelpunt\" het bloknummer in van de eerste transactie die voor dit adres is gebruikt. Je kunt ook een datum gebruiken, met de indeling JJJJ-MM-DD. Als je het niet zeker weet, kun je een schatting invoeren van de datum/blokhoogte <em>voordat</em> je het adres van deze portemonnee voor het eerst hebt gebruikt.</p>
+    ]]></string>
+
+    <string name="help_details"><![CDATA[
+        <h1>Portemonneegegevens</h1>
+        <h2>Openbaar adres</h2>
+        Je openbare adres is te vergelijken met een bankrekeningnummer dat je aan iedereen kunt geven zonder het risico te lopen dat je je moneroj kwijtraakt. Anderen gebruiken dit adres om moneroj naar jouw portemonnee te sturen.
+        <h2>Hersteltekst</h2>
+        Dit is het enige dat je nodig hebt om later je portemonnee te herstellen en volledige toegang tot je geld te krijgen. Het is belangrijk om deze gegevens verborgen te houden, want hiermee kan <em>iedereen</em> volledige toegang tot je moneroj krijgen. Als je de hersteltekst nog niet hebt opgeschreven op een veilige plek, doe het dan nu!
+        <h2>Wachtwoord voor portemonneebestanden</h2>
+        Zorg dat je dit wachtwoord opschrijft. Als je dit apparaat opnieuw instelt of de app verwijdert, heb je dit wachtwoord nodig om je portemonnee weer te gebruiken.<br/>
+        <h3>CrAzYpass</h3>
+        Als dit wachtwoord bestaat uit 52 alfanumerieke tekens in groepen van 4 - gefeliciteerd!
+        Je portemonneebestanden worden beveiligd met een 256-bits sleutel die is gegenereerd door beveiligingsfuncties van je apparaat op basis van de wachtzin die je hebt gekozen (door deze te maken of te wijzigen). Dit maakt het erg moeilijk om te hacken!<br/>
+        Deze functie is verplicht voor alle nieuw gemaakte portemonnees.
+        <h3>Ouderwets wachtwoord</h3>
+        Als je wachtzin hierbij staat, zijn je portemonneebestanden niet zo goed beveiligd als wanneer je CrAzYpass gebruikt. Selecteer \"Wachtzin wijzigen\" in het menu om dit op te lossen. Nadat je een nieuwe wachtzin hebt ingevoerd (of dezelfde als de vorige keer), wordt er een nieuwe CrAzYpass voor je gegenereerd, waarmee je portemonneebestanden worden beveiligd. Schrijf deze op!
+        <h3>Portemonnee met CrAzYpass</h3>
+        Als je Monerujo ooit opnieuw moet installeren (bijvoorbeeld als je je telefoon opnieuw hebt ingesteld of als je een nieuwe telefoon hebt) of als je je portemonneebestanden op een ander apparaat of een computer wilt gebruiken, moet je dit herstelwachtwoord invoeren om weer toegang tot je portemonnee te krijgen.<br/>
+        Door \"Wachtzin wijzigen\" te selecteren in het menu kun je een andere wachtzin kiezen. Let op: hierdoor wordt een nieuw herstelwachtwoord gegenereerd. Schrijf het op!
+        <h2>Alleen-lezen sleutel</h2>
+        Met je alleen-lezen sleutel kunnen binnenkomende transacties voor je portemonnee worden gevolgd zonder toestemming te geven om het geld in je portemonnee uit te geven.
+        <h2>Bestedingssleutel</h2>
+        Met je bestedingssleutel kan iedereen de moneroj in je portemonnee uitgeven. Laat deze sleutel dus aan niemand zien; bewaar hem veilig, net als je hersteltekst.
+    ]]></string>
+
+    <string name="help_list"><![CDATA[
+        <h1>Portemonneelijst</h1>
+        <h2>Node</h2>
+        <p>Monerujo gebruikt een externe node om te communiceren met het Monero-netwerk zonder zelf een exemplaar van de hele blockchain te hoeven downloaden en opslaan. Hier vind je een lijst met populaire externe nodes, of kun je leren hoe je er zelf een draait: https://moneroworld.com/<p>
+        <p>Bepaalde externe nodes zijn vooraf ingesteld in Monerujo. De laatste vijf gebruikte nodes worden onthouden.</p>
+        <h2>Portemonnees</h2>
+        <p>Hier worden je portemonnees weergegeven. Ze zijn opgeslagen in de map <tt>monerujo</tt> in de interne opslag van je apparaat. Je kunt ze vinden in een bestandenverkenner-app.
+        Maak regelmatig back-ups van deze map naar opslag elders, voor het geval dat je apparaat in brand vliegt of wordt gestolen.</p>
+        <p>Selecteer een portemonnee om te openen of tik op de \"+\" om een nieuwe te maken.
+        Of selecteer een van de portemonnee-bewerkingen:</p>
+        <h3>Details</h3>
+        <p>Details, hersteltekst en sleutels weergeven.</p>
+        <h3>Ontvangen</h3>
+        <p>Een QR-code maken voor het ontvangen van moneroj.</p>
+        <h3>Hernoemen</h3>
+        <p>De portemonnee een andere naam geven. De naam van back-ups wordt niet veranderd.</p>
+        <h3>Back-up</h3>
+        <p>Een kopie maken van de portemonnee in de map <tt>backups</tt> in de map <tt>monerujo</tt>. Hierdoor worden eerdere kopieën overschreven.</p>
+        <h3>Archiveren</h3>
+        <p>Een back-up maken en vervolgens de portemonnee verwijderen. De kopie blijft in de map <tt>backups</tt> staan. Heb je je back-ups niet meer nodig? Verwijder ze dan met een bestandenverkenner of verwijder de app veilig.</p>
+    ]]></string>
+
+    <string name="help_wallet"><![CDATA[
+        <h1>De portemonnee</h1>
+        <h2>Scannen</h2>
+        Omdat Monero graag alles geheim houdt, scannen we iedere keer als je een Monerujo-portemonnee opent de blockchain om te kijken of er nieuwe moneroj naar je portemonnee zijn overgemaakt. Hierbij wordt alleen informatie die bij je portemonnee hoort opgeslagen op je telefoon. Soms kan het even duren als je een tijd niet hebt gesynchroniseerd.
+        <h2>Het saldo</h2>
+        <p><b>Help! Het saldo van mijn portemonnee is verdwenen of niet bevestigd!</b><br/>
+        Geen paniek! Wanneer je geld uit je portemonnee verzend, wordt een deel van je saldo tijdelijk aangegeven als onbevestigd.
+        Dit is het gevolg van hoe Monero wordt gemengd op de blockchain en hoe wisselgeld werkt.
+        Lees meer over wisselgeld op https://getmonero.org/resources/moneropedia/change.html
+        <h2>Transactielijst</h2>
+        <p>Een lijst van de transacties van de portemonnee. In een alleen-lezen portemonnee worden alleen binnenkomende transacties weergegeven.</p>
+    ]]></string>
+
+    <string name="help_tx_details"><![CDATA[
+        <h1>Transactiedetails</h1>
+        <h2>Bestemming</h2>
+        Dit is het openbare adres van de portemonnee waarnaar je Monero verstuurt.
+        <h2>Betalings-ID</h2>
+        Je kunt een Betalings-ID gebruiken om aan te geven waarom je Monero verzendt. Dit is volledig optioneel en blijft vertrouwelijk tussen beide partijen. Een bedrijf kan bijvoorbeeld jouw transactie koppelen aan een artikel dat je hebt gekocht.
+        <h2>Transactie-ID</h2>
+        Met je transactie-ID kun je de versleutelde transactie vinden in een Monero-blockexplorer, bijvoorbeeld <a href="https://xmrchain.net/">https://xmrchain.net/</a>
+        <h2>Transactiesleutel</h2>
+        Dit is de geheime sleutel van je transactie. Bewaar deze veilig, want als iemand bekendmaakt welke handtekening in een ring van jou is, wordt je transactie openbaar.
+        <h2>Blok</h2>
+        Dit is het blok waarin je transactie is opgenomen.
+    ]]></string>
+
+    <string name="help_send"><![CDATA[
+        <h1>Verzenden</h1>
+        <h2>Adres ontvanger</h2>
+        <p>Dit is het openbare adres van de portemonnee waar je moneroj naartoe stuurt. Je kunt dit kopiëren via het klembord, een QR-code scannen of het adres handmatig invoeren. Controleer dit nauwkeurig om er zeker van te zijn dat je geen geld naar het verkeerde adres stuurt.</p>
+        <p>Je kunt niet alleen XMR verzenden, maar ook BTC via XMR.TO (zie https://xmr.to
+        voor meer informatie). Zie ook het gedeelte over BTC verzenden hieronder.</p>
+        <h2>Betalings-ID</h2>
+        <p>Je kunt een Betalings-ID gebruiken om aan te geven waarom je Monero verzendt. Dit is volledig optioneel en blijft vertrouwelijk tussen beide partijen. Een bedrijf kan bijvoorbeeld jouw transactie koppelen aan een artikel dat je hebt gekocht.<p>
+        <h2>Ringgrootte</h2>
+        <p>Je kunt kiezen uit een aantal ringgrootten in Monerujo. Als je een beginnende gebruiker bent, raden we je aan om de standaardgrootte 7 te gebruiken. Een ringgrootte van meer dan 7 betekent dat een ring-handtekening meer ondertekenaars bevat. In theorie is dat beter voor een plausibele ontkenning. Maar een hogere ringgrootte kan er ook toe leiden dat je transactie opvalt op de blockchain.</p>
+        <h2>Prioriteit</h2>
+        <p>Deze instelling bepaalt de snelheid waarmee je transactie wordt vastgelegd op de blockchain. Voor een hoge prioriteit betaal je hogere transactiekosten, terwijl een lagere prioriteit goedkoper is. Als je een lage prioriteit instelt, kan het uren duren voordat je transactie wordt vastgelegd op de blockchain. De standaardprioriteit is \"Normaal\".</p>
+        <h1>BTC verzenden</h1>
+        <h2>XMR.TO</h2>
+        <p>XMR.TO is een externe service waarmee je Monero kunt inwisselen voor Bitcoin.
+        We gebruiken de API van XMR.TO om Bitcoin-betalingen te integreren in Monerujo. Neem eens een kijkje op https://xmr.to en besluit zelf of je dit wilt gebruiken. Het Monerujo-team is niet verbonden aan XMR.TO en kan je niet helpen met deze service.</p>
+        <h2>Wisselkoers XMR.TO<h2>
+        <p>Op het scherm \"Bedrag\" worden de huidige waarden voor het gebruik van XMR.TO weergegeven. Hierbij staat de huidige wisselkoers, maar ook het maximale en minimale BTC-bedrag. Houd er rekening mee dat deze koers op dit moment nog niet wordt gegarandeerd. Je ziet hier ook het maximale bedrag waarvoor de BTC-transactie meteen wordt uitgevoerd zonder te wachten op XMR-bevestigingen (zie de FAQ van XMR.TO voor meer informatie). En het mooiste is dat XMR.TO geen extra transactiekosten rekent. Hoe cool is dat?</p>
+        <h2>XMR.TO-opdracht<h2>
+        <p>Op het scherm \"Bevestigen\" wordt de eigenlijke XMR.TO-opdracht weergegeven. Deze opdracht is geldig voor een beperkte tijd. Er wordt afgeteld op de knop \"Uitgeven\". De wisselkoers kan hier anders zijn dan de schatting die op eerdere schermen is weergegeven.</p>
+        <h2>Geheime sleutel XMR.TO<h2>
+        <p>Omdat Monerujo alleen het Monero-gedeelte van je transactie verwerkt, kun je je geheime sleutel voor XMR.TO gebruiken om het Bitcoin-gedeelte van de opdracht te volgen op de XMR.TO-website.</p>
+        <p>Houd er rekening mee dat deze geheime sleutel maar 24 uur geldig is nadat de transactie is gestart!</p>
+        <h2>XMR.TO telt af!</h2>
+        <p>Als de knop heeft afgeteld naar nul, moet je een nieuw aanbod van XMR.TO aanvragen. Ga daarvoor terug naar de vorige stap en open het scherm \"Bevestigen\" opnieuw.</p>
+    ]]></string>
+
+    <string name="help_xmrto"><![CDATA[
+        <h1>BTC verzenden</h1>
+        <h2>XMR.TO</h2>
+        <p>XMR.TO is een externe service waarmee je Monero kunt inwisselen voor Bitcoin.
+        We gebruiken de API van XMR.TO om Bitcoin-betalingen te integreren in Monerujo. Neem eens een kijkje op https://xmr.to en besluit zelf of je dit wilt gebruiken. Het Monerujo-team is niet verbonden aan XMR.TO en kan je niet helpen met deze service.</p>
+        <h2>Wisselkoers XMR.TO<h2>
+        <p>Op het scherm \"Bedrag\" worden de huidige waarden voor het gebruik van XMR.TO weergegeven. Hierbij staat de huidige wisselkoers, maar ook het maximale en minimale BTC-bedrag. Houd er rekening mee dat deze koers op dit moment nog niet wordt gegarandeerd. Je ziet hier ook het maximale bedrag waarvoor de BTC-transactie meteen wordt uitgevoerd zonder te wachten op XMR-bevestigingen (zie de FAQ van XMR.TO voor meer informatie). En het mooiste is dat XMR.TO geen extra transactiekosten rekent. Hoe cool is dat?</p>
+        <h2>XMR.TO-opdracht<h2>
+        <p>Op het scherm \"Bevestigen\" wordt de eigenlijke XMR.TO-opdracht weergegeven. Deze opdracht is geldig voor een beperkte tijd. Er wordt afgeteld op de knop \"Uitgeven\". De wisselkoers kan hier anders zijn dan de schatting die op eerdere schermen is weergegeven.</p>
+        <h2>Geheime sleutel XMR.TO<h2>
+        <p>Omdat Monerujo alleen het Monero-gedeelte van je transactie verwerkt, kun je je geheime sleutel voor XMR.TO gebruiken om het Bitcoin-gedeelte van de opdracht te volgen op de XMR.TO-website.</p>
+        <p>Houd er rekening mee dat deze geheime sleutel maar 24 uur geldig is nadat de transactie is gestart!</p>
+        <h2>XMR.TO telt af!</h2>
+        <p>Als de knop heeft afgeteld naar nul, moet je een nieuw aanbod van XMR.TO aanvragen. Ga daarvoor terug naar de vorige stap en open het scherm \"Bevestigen\" opnieuw.</p>
+    ]]></string>
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,347 @@
+<resources>
+    <string name="wallet_activity_name">Portemonnee</string>
+
+    <string name="menu_about">Info</string>
+    <string name="menu_privacy">Privacybeleid</string>
+
+    <string name="menu_share">Delen</string>
+    <string name="menu_help">Help</string>
+    <string name="menu_info">Details</string>
+    <string name="menu_receive">Ontvangen</string>
+    <string name="menu_rename">Hernoemen…</string>
+    <string name="menu_archive">Archiveren</string>
+    <string name="menu_backup">Back-up</string>
+    <string name="menu_changepw">Wachtzin wijzigen</string>
+
+    <string name="password_weak">Blijf typen…</string>
+    <string name="password_fair">Mwah…</string>
+    <string name="password_good">Kom op, dat kan beter!</string>
+    <string name="password_strong">Je bent er bijna…</string>
+    <string name="password_very_strong">Ja, nu ben je een hacker!</string>
+
+    <string name="label_login_wallets">Portemonnees</string>
+    <string name="label_credits">Makers</string>
+    <string name="label_ok">OK</string>
+    <string name="label_cancel">Annuleren</string>
+    <string name="label_close">Sluiten</string>
+    <string name="label_wallet_advanced_details">Tik voor meer informatie</string>
+
+    <string name="label_send_success">Verzonden</string>
+    <string name="label_send_done">Klaar</string>
+
+    <string name="label_receive_info_gen_qr_code">Tik voor QR-code</string>
+    <string name="info_send_prio_fees">Hogere prioriteit = hogere kosten</string>
+
+    <string name="info_xmrto_enabled">BTC-betaling ingeschakeld. Tik voor meer info.</string>
+    <string name="info_crazypass_enabled">CrAzYpass ingeschakeld. Tik voor meer info.</string>
+    <string name="info_ledger_enabled">Ledger ingeschakeld. Tik voor meer info.</string>
+
+    <string name="info_xmrto"><![CDATA[
+        <b>Je hebt een Bitcoin-adres ingevoerd.</b><br/>
+        <i>Je verzendt XMR en de ontvanger krijgt BTC via <b>XMR.TO</b>.</i>
+    ]]></string>
+
+    <string name="info_send_xmrto_success_order_label">XMR.TO-opdracht</string>
+
+    <string name="info_send_xmrto_success_btc">%1$s BTC</string>
+
+    <string name="info_send_xmrto_paid">Wacht op bevestiging</string>
+    <string name="info_send_xmrto_unpaid">Wacht op betaling</string>
+    <string name="info_send_xmrto_error">Fout bij XMR.TO (%1$s)</string>
+    <string name="info_send_xmrto_sent">BTC verzonden!</string>
+    <string name="info_send_xmrto_query">Aanvragen…</string>
+
+    <string name="info_send_xmrto_parms"><![CDATA[
+        <b>Je kunt  %1$s &#8212; %2$s BTC verzenden</b>.<br/>
+        <i><b>XMR.TO</b> biedt <u>nu</u> een wisselkoers van <b>%3$s BTC</b> aan</i>.
+    ]]></string>
+    <string name="info_send_xmrto_zeroconf"><![CDATA[
+        <i>Bedragen tot <b>%1$s BTC</b> worden <u>meteen</u> verzonden!</i>
+    ]]></string>
+
+    <string name="send_available_btc">Saldo: %2$s BTC (%1$s XMR)</string>
+
+    <string name="info_paymentid_intergrated">Betalings-ID geïntegreerd</string>
+    <string name="info_prepare_tx">Transactie wordt voorbereid</string>
+
+    <string name="label_send_progress_xmrto_create">XMR.TO-opdracht maken</string>
+    <string name="label_send_progress_xmrto_query">XMR.TO-opdracht aanvragen</string>
+    <string name="label_send_progress_create_tx">Monero-transactie voorbereiden</string>
+
+    <string name="label_send_progress_queryparms">XMR.TO-parameters aanvragen</string>
+
+    <string name="label_generic_xmrto_error">FOUT BIJ XMR.TO</string>
+    <string name="text_generic_xmrto_error">Code: %1$d</string>
+
+    <string name="text_retry">Opnieuw proberen</string>
+    <string name="text_noretry_monero">Nu zitten we vast…</string>
+    <string name="text_noretry">Oeps, XMR.TO is op dit moment niet beschikbaar.</string>
+
+    <string name="text_send_btc_amount">%1$s BTC = %2$s XMR</string>
+    <string name="text_send_btc_rate">(Koers: %1$s BTC/XMR)</string>
+
+    <string name="label_send_settings_advanced">Geavanceerd:</string>
+
+    <string name="label_send_btc_xmrto_info">Ga naar xmr.to voor hulp en traceren</string>
+    <string name="label_send_btc_xmrto_key_lb">Geheime sleutel\nXMR.TO</string>
+    <string name="label_send_btc_xmrto_key">Geheime sleutel XMR.TO</string>
+    <string name="label_send_btc_address">BTC-doeladres</string>
+    <string name="label_send_btc_amount">Bedrag</string>
+
+    <string name="label_send_txid">Transactie-ID</string>
+    <string name="label_send_address">Doeladres</string>
+    <string name="label_send_payment_id">Betalings-ID</string>
+    <string name="label_send_notes">Opmerkingen</string>
+
+    <string name="backup_progress">Back-up wordt gemaakt</string>
+    <string name="archive_progress">Wordt gearchiveerd</string>
+    <string name="rename_progress">Naam wordt gewijzigd</string>
+    <string name="open_progress">Verbinding met node controleren</string>
+    <string name="changepw_progress">Wachtwoord wordt gewijzigd</string>
+
+    <string name="service_progress">Bezig met voltooien…\nDit kan even duren.</string>
+
+    <string name="backup_failed">Back-up mislukt!</string>
+    <string name="archive_failed">Archiveren mislukt!</string>
+    <string name="rename_failed">Hernoemen mislukt!</string>
+    <string name="changepw_failed">Wachtwoord wijzigen mislukt!</string>
+    <string name="changepw_success">Wachtwoord is gewijzigd</string>
+
+    <string name="label_daemon">Node</string>
+    <string name="prompt_daemon">([&lt;user&gt;:&lt;pass&gt;@]&lt;daemon&gt;[:&lt;port&gt;])</string>
+    <string name="status_wallet_loading">Portemonnee laden…</string>
+    <string name="status_wallet_unloaded">Portemonnee opgeslagen</string>
+    <string name="status_wallet_unload_failed">Portemonnee opslaan mislukt!</string>
+    <string name="status_wallet_connecting">Verbinden…</string>
+    <string name="status_wallet_connect_failed">Geen verbinding met node.\nControleer naam/wachtwoord.</string>
+    <string name="status_wallet_connect_timeout">Time-out verbinding met node.\nProbeer opnieuw of andere.</string>
+    <string name="status_wallet_node_invalid">Node ongeldig.\nProbeer een andere.</string>
+    <string name="status_wallet_connect_ioex">Kan node niet bereiken.\nProbeer opnieuw of andere.</string>
+
+    <string name="status_wallet_disconnected">Geen verbinding</string>
+
+    <string name="status_transaction_failed">Transactie mislukt: %1$s</string>
+
+    <string name="send_xmrto_timeout">Je hebt te lang gewacht, vriend!</string>
+
+    <string name="service_busy">Ik ben nog bezig met de vorige…</string>
+
+    <string name="prompt_rename">%1$s hernoemen</string>
+
+    <string name="prompt_changepw">Nieuwe wachtzin voor %1$s</string>
+    <string name="prompt_changepwB">Herhaal wachtzin voor %1$s</string>
+    <string name="prompt_password">Wachtwoord voor %1$s</string>
+    <string name="prompt_fingerprint_auth">Je kunt ook je vingerafdruk gebruiken.\nRaak de sensor aan.</string>
+    <string name="prompt_send_password">Bevestig wachtwoord</string>
+    <string name="prompt_open_wallet">Portemonnee openen…</string>
+    <string name="bad_fingerprint">Vingerafdruk niet herkend. Probeer het opnieuw.</string>
+    <string name="bad_password">Onjuist wachtwoord!</string>
+    <string name="bad_saved_password">Opgeslagen wachtwoord is onjuist\nVoer wachtwoord handmatig in.</string>
+    <string name="bad_wallet">Portemonnee bestaat niet!</string>
+    <string name="prompt_daemon_missing">Node-adres moet ingesteld zijn!</string>
+    <string name="prompt_wrong_net">Portemonnee komt niet overeen met netwerk</string>
+
+    <string name="label_watchonly">(Alleen-lezen)</string>
+
+    <string name="label_wallet_receive">Ontvangen</string>
+    <string name="label_wallet_send">Geven</string>
+
+    <string name="xmr_unconfirmed_amount">+ %1$s XMR onbevestigd</string>
+
+    <string name="service_description">monerujo-service</string>
+
+    <string name="status_synced">Gesynchroniseerd:</string>
+    <string name="status_remaining">Blokken te gaan</string>
+    <string name="status_syncing">Scannen:</string>
+
+    <string name="message_strorage_not_writable">Kan niet schrijven naar externe opslag! Help!</string>
+    <string name="message_strorage_not_permitted">We hebben die machtiging voor Externe Opslag nodig!</string>
+    <string name="message_camera_not_permitted">Geen camera = geen QR-codes scannen!</string>
+
+    <string name="label_copy_viewkey">Alleen-lezen sleutel</string>
+    <string name="label_copy_address">Openbaar adres</string>
+    <string name="label_copy_xmrtokey">Sleutel XMR.TO</string>
+    <string name="message_copy_viewkey">Alleen-lezen sleutel gekopieerd naar klembord!</string>
+    <string name="message_copy_xmrtokey">Sleutel XMR.TO gekopieerd naar klembord!</string>
+    <string name="message_copy_address">Portemonnee-adres gekopieerd naar klembord!</string>
+    <string name="message_copy_txid">Transactie-ID gekopieerd naar klembord!</string>
+    <string name="message_nocopy">Kopiëren uitgeschakeld voor de veiligheid!</string>
+
+    <string name="message_exchange_failed">Kan wisselkoers niet ophalen!\nGebruik XMR/XMR of probeer opnieuw</string>
+
+    <string name="generate_title">Portemonnee maken</string>
+    <string name="generate_name_hint">Naam portemonnee</string>
+    <string name="generate_password_hint">Wachtwoord portemonnee</string>
+    <string name="generate_fingerprint_hint">Openen met vingerafdruk toestaan</string>
+    <string name="generate_fingerprint_warn"><![CDATA[
+        strong>Verificatie met vingerafdruk</strong>
+        <p>Als je verificatie met vingerafdruk toestaat, kun je het saldo van je portemonnee bekijken en geld ontvangen zonder een wachtwoord in te voeren.</p>
+        <p>Maar voor de veiligheid vereist monerujo wel dat je een wachtwoord invoert om details van de portemonnee te bekijken of geld over te maken.</p>
+        <strong>Beveiligingswaarschuwing</strong>
+        <p>Houd er rekening mee dat iedereen die toegang heeft tot je vingerafdruk het saldo van je portemonnee kan bekijken.</p>
+        <p>Een kwaadwillige gebruiker kan bijvoorbeeld je portemonnee openen terwijl je slaapt.</p>
+        <strong>Weet je zeker dat je deze functie wilt inschakelen?</strong>
+    ]]></string>
+    <string name="generate_bad_passwordB">Wachtwoorden komen niet overeen</string>
+    <string name="generate_empty_passwordB">Wachtwoord mag niet leeg zijn</string>
+    <string name="generate_buttonGenerate">Maak die portemonnee nou maar!</string>
+    <string name="generate_button_accept">Ik heb de hersteltekst opgeschreven</string>
+
+    <string name="generate_wallet_name">Geef me een naam!</string>
+    <string name="generate_wallet_exists">Portemonnee bestaat al!</string>
+    <string name="generate_wallet_dot">Mag niet beginnen met .</string>
+    <string name="generate_wallet_creating">Portemonnee wordt gemaakt</string>
+    <string name="generate_wallet_created">Portemonnee is gemaakt</string>
+    <string name="generate_wallet_create_failed">Portemonnee maken mislukt!</string>
+
+    <string name="generate_restoreheight_error">Voer getal of datum (JJJJ-MM-DD) in</string>
+
+    <string name="generate_wallet_type_key">Sleutels</string>
+    <string name="generate_wallet_type_new">Nieuw</string>
+    <string name="generate_wallet_type_seed">Hersteltekst</string>
+    <string name="generate_wallet_type_view">Alleen-lezen</string>
+
+    <string name="generate_address_hint">Openbaar adres</string>
+    <string name="generate_viewkey_hint">Alleen-lezen sleutel</string>
+    <string name="generate_spendkey_hint">Bestedingssleutel</string>
+    <string name="generate_mnemonic_hint">Hersteltekst van 25 woorden</string>
+    <string name="generate_restoreheight_hint">Herstelpunt of datum (JJJJ-MM-DD)</string>
+
+    <string name="generate_address_label">Openbaar adres</string>
+    <string name="generate_viewkey_label">Alleen-lezen sleutel</string>
+    <string name="generate_spendkey_label">Bestedingssleutel</string>
+    <string name="generate_mnemonic_label">Hersteltekst</string>
+    <string name="generate_crazypass_label">Wachtwoord voor portemonneebestanden</string>
+
+    <string name="generate_check_key">Voer geldige sleutel in</string>
+    <string name="generate_check_address">Voer geldig adres in</string>
+    <string name="generate_check_mnemonic">Voer je 25 woorden in</string>
+
+    <string name="send_amount_btc_xmr">%1$s (schatting)</string>
+
+    <string name="send_address_hint">XMR- of BTC-adres ontvanger</string>
+    <string name="send_paymentid_hint">Betalings-ID (optioneel)</string>
+    <string name="send_amount_hint">0,00</string>
+    <string name="send_notes_hint">Opmerkingen voor jezelf (optioneel)</string>
+    <string name="send_generate_paymentid_hint">Genereren</string>
+    <string name="send_send_label">Geef mijn mooie moneroj uit</string>
+    <string name="send_send_timed_label">Geef mijn mooie moneroj uit (%1$s)</string>
+    <string name="send_qr_invalid">Geen QR-code</string>
+    <string name="send_qr_address_invalid">Geen geldige QR-code voor betaling</string>
+    <string name="send_address_invalid">Geen geldig adres</string>
+    <string name="send_title">Verzenden</string>
+    <string name="send_available">Saldo: %1$s XMR</string>
+    <string name="send_address_title">Adres</string>
+    <string name="send_amount_title">Bedrag</string>
+    <string name="send_settings_title">Instellingen</string>
+    <string name="send_confirm_title">Bevestigen</string>
+    <string name="send_success_title">Klaar</string>
+
+    <string name="send_amount_label">Bedrag</string>
+    <string name="send_fee_btc_label">Vergoeding (XMR)</string>
+    <string name="send_fee_label">Vergoeding</string>
+    <string name="send_total_btc_label">Totaal (XMR)</string>
+    <string name="send_total_label">Totaal</string>
+
+    <string name="send_amount">%1$s XMR</string>
+    <string name="send_fee">+%1$s kosten</string>
+
+    <string name="send_create_tx_error_title">Fout bij transactie maken</string>
+
+    <string name="tx_list_fee">- kosten %1$s</string>
+    <string name="tx_list_amount_failed">(%1$s)</string>
+    <string name="tx_list_failed_text">mislukt</string>
+    <string name="tx_list_amount_negative">- %1$s</string>
+    <string name="tx_list_amount_positive">+ %1$s</string>
+
+    <string name="tx_timestamp">Tijdstempel</string>
+    <string name="tx_id">Transactie-ID</string>
+    <string name="tx_key">Transactiesleutel</string>
+    <string name="tx_destination">Bestemming</string>
+    <string name="tx_destination_btc">Bestemming\nBTC</string>
+    <string name="tx_paymentId">Betalings-ID</string>
+    <string name="tx_blockheight">Blok</string>
+    <string name="tx_amount">Bedrag</string>
+    <string name="tx_amount_btc">Bedrag\nBTC</string>
+    <string name="tx_fee">Vergoeding</string>
+    <string name="tx_transfers">Betalingen</string>
+    <string name="tx_notes">Opmerkingen</string>
+    <string name="tx_notes_hint">(optioneel)</string>
+    <string name="tx_button_notes">Opslaan</string>
+    <string name="tx_notes_set_failed">Opmerkingen opslaan mislukt</string>
+    <string name="tx_title">Transactiedetails</string>
+
+    <string name="tx_pending">WACHTEN</string>
+    <string name="tx_failed">MISLUKT</string>
+
+    <string name="receive_paymentid_hint">Betalings-ID (optioneel)</string>
+    <string name="receive_amount_hint">Bedrag</string>
+    <string name="receive_cannot_open">Kan portemonnee niet openen!</string>
+    <string name="receive_paymentid_invalid">16 of 64 hexadecimale tekens (0–9, a–f)</string>
+    <string name="receive_integrated_paymentid_invalid">Moet leeg zijn bij een geïntegreerd adres</string>
+
+    <string name="receive_amount_too_big">Max. %1$s</string>
+    <string name="receive_amount_negative">Min. 0</string>
+    <string name="receive_amount_nan">XMR geen getal</string>
+
+    <string name="receive_title">Ontvangen</string>
+
+    <string name="details_alert_message">Nu worden vertrouwelijke gegevens getoond.\nKijk achter je!</string>
+    <string name="details_alert_yes">Het is veilig.</string>
+    <string name="details_alert_no">Ga terug!</string>
+    <string name="details_title">Details</string>
+
+    <string name="archive_alert_message">Er wordt een back-up gemaakt en daarna wordt de portemonnee verwijderd!</string>
+    <string name="archive_alert_yes">Ja, doe dat!</string>
+    <string name="archive_alert_no">Nee, niet doen!</string>
+
+    <string-array name="priority">
+        <item>Prioriteit Normaal</item>
+        <item>Prioriteit Laag</item>
+        <item>Prioriteit Normaal</item>
+        <item>Prioriteit Hoog</item>
+    </string-array>
+
+    <string name="fab_create_new">Nieuwe portemonnee</string>
+    <string name="fab_restore_viewonly">Alleen-lezen portemonnee herstellen</string>
+    <string name="fab_restore_key">Portemonnee herstellen met privésleutels</string>
+    <string name="fab_restore_seed">Voer je 25 woorden in</string>
+
+    <string name="accounts_drawer_new">Account maken</string>
+    <string name="accounts_drawer_title">Accounts</string>
+    <string name="accounts_new">Nieuw account #%1$d toegevoegd</string>
+    <string name="tx_account">Accountnr.</string>
+
+    <string name="send_sweepall">Al het bevestigde geld in dit account verzenden!</string>
+    <string name="tx_subaddress">Subadres #%1$d</string>
+    <string name="generate_address_label_sub">Openbaar subadres #%1$d</string>
+
+    <string name="menu_language">Taal</string>
+    <string name="language_system_default">Systeemtaal gebruiken</string>
+
+    <string name="fab_restore_ledger">Herstellen met Ledger Nano S</string>
+
+    <string name="progress_ledger_progress">Communiceren met Ledger…</string>
+    <string name="progress_ledger_confirm">Bevestiging op Ledger vereist!</string>
+    <string name="progress_ledger_lookahead">Subadressen ophalen…</string>
+    <string name="progress_ledger_verify">Sleutels verifiëren…</string>
+    <string name="progress_ledger_opentx">Magisch rekenwerk…</string>
+    <string name="progress_ledger_mlsag">Hashes berekenen…</string>
+    <string name="open_wallet_ledger_missing">Maak (opnieuw) verbinding met Ledger</string>
+
+    <string name="accounts_progress_new">Account maken…</string>
+    <string name="accounts_progress_update">Portemonnee bijwerken…</string>
+
+    <string name="toast_ledger_attached">%1$s gekoppeld</string>
+    <string name="toast_ledger_detached">%1$s losgemaakt</string>
+
+    <string name="progress_nfc_write">Tag wordt geschreven</string>
+    <string name="nfc_write_failed">Tag schrijven mislukt!</string>
+    <string name="nfc_write_successful">Tag is geschreven</string>
+    <string name="nfc_tag_unsupported">Tag ondersteunt NDEF niet!</string>
+    <string name="nfc_tag_size">Tag levert %d bytes, maar we hebben er %d nodig!</string>
+    <string name="nfc_tag_read_undef">Ik begrijp de Tag niet!</string>
+    <string name="nfc_tag_read_what">Ik weet niet wat je wilt!</string>
+    <string name="nfc_tag_read_success">Tag is gelezen</string>
+    <string name="nfc_tag_tap">NFC beschikbaar!</string>
+</resources>


### PR DESCRIPTION
Hi, I translated Monerujo into Dutch, thanks to FFS donations from the awesome Monero community. 

Technical notes: I made sure to escape all double quotes, and to my surprise, I haven't used single quotes at all. XML tags were protected and not even displayed by my translation tool (Trados). I ignored indentations within text strings.

Language notes: With regard to issue #284, I used different terms for *password* and *passphrase*, and I used the same translations consistently. We'll update the translation later once you rewrite the help strings. For reviewers: note that the menu text in strings.xml should be as short as possible. This is why I used 'Hernoemen' rather than 'Naam wijzigen', for example.

The playful style was fun - I hope the translation does it justice.