### PR TITLE
Add node version warning

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -352,5 +352,5 @@
     <string name="send_address_resolve_openalias">OpenAlias omzetten&#8230;</string>
     <string name="send_address_no_dnssec">OpenAlias zonder DNSSEC - adres kan nep zijn</string>
 
-    <string name="status_wallet_connect_wrongversion">Node version incompatible - please upgrade!</string>
+    <string name="status_wallet_connect_wrongversion">Incompatibele versie van node. Je moet upgraden!</string>
 </resources>


### PR DESCRIPTION
In addition to #429, for monero v0.13 upgrade.