### PR TITLE
(optional) disable crazypass generation

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/Helper.java
@@ -81,6 +81,8 @@ public class Helper {
             (BuildConfig.FLAVOR.startsWith("prod") ? "" : "." + BuildConfig.FLAVOR)
                     + (BuildConfig.DEBUG ? "-debug" : "");
 
+    static public final String NOCRAZYPASS_FLAGFILE = ".nocrazypass";
+
     static public final String CRYPTO = "XMR";
 
     static private final String WALLET_DIR = "monerujo" + FLAVOR_SUFFIX;
@@ -345,6 +347,11 @@ public class Helper {
         WalletManager.initLogger(home + "/monerujo", "monerujo.log");
         if (level >= WalletManager.LOGLEVEL_SILENT)
             WalletManager.setLogLevel(level);
+    }
+
+    static public boolean useCrazyPass(Context context) {
+        File flagFile = new File(getWalletRoot(context), NOCRAZYPASS_FLAGFILE);
+        return !flagFile.exists();
     }
 
     // try to figure out what the real wallet password is given the user password

--- a/app/src/main/java/com/m2049r/xmrwallet/util/KeyStoreHelper.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/KeyStoreHelper.java
@@ -84,7 +84,10 @@ public class KeyStoreHelper {
     }
 
     public static String getCrazyPass(Context context, String password) {
-        return getCrazyPass(context, password, 0);
+        if (Helper.useCrazyPass(context))
+            return getCrazyPass(context, password, 0);
+        else
+            return password;
     }
 
     public static String getBrokenCrazyPass(Context context, String password, int brokenVariant) {

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -91,3 +91,10 @@ Keep calm and make a new wallet.
 
 ## Why does it make a 'monero' folder?
 This is a new feature of monero core to share certain key images with other monero forks.
+
+## CrAzYpass is awesome - but I don't want it!
+Creating a file named `.nocrazypass` in the wallets folder will disable generation of crazypass for NEW passwords (new wallet or change password).
+The content of the file is not read and is irrelevant.
+Wallets with CrAzYpass will continue working normally. The currently set real wallet password can be checked in the "Show Secrets".
+
+**NB: This feature is for test purposed only - all your XMR will be stolen if you use it!**


### PR DESCRIPTION
**NB: This feature is for test purposed only - all your XMR will be stolen if you use it!**
- creating a file named ".nocrazypass" in the wallets folder will disable generation of crazypass for NEW passwords (new wallet or change password)
- wallets with crazypass will continue working normally (i.e. with crazypass)
- current real wallet password can be checked in the "Show Secrets".