### PR TITLE
don't setDaemon when null

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/model/WalletManager.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/WalletManager.java
@@ -287,7 +287,8 @@ public class WalletManager {
             this.daemonAddress = null;
             this.daemonUsername = "";
             this.daemonPassword = "";
-            setDaemonAddressJ("");
+            //setDaemonAddressJ(""); // don't disconnect as monero code blocks for many seconds!
+            //TODO: need to do something about that later
         }
     }
 


### PR DESCRIPTION
setDaemon() blocks in monero core for many seconds trying to connect/disconnect. so we don't do it if we don't have a new node to connect to.
the test if we have a node is local to the java model, so it should not matter (much).