### PR TITLE
[WIP] Display 'Connecting...' when connection to daemon is lost

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -230,7 +230,7 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
             final WalletFragment walletFragment = getWalletFragment();
             getWallet().rescanBlockchainAsync();
             synced = false;
-            walletFragment.unsync();
+            walletFragment.onStartRescan();
             invalidateOptionsMenu();
         } catch (ClassCastException ex) {
             Timber.d(ex.getLocalizedMessage());

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
@@ -374,6 +374,10 @@ public class WalletFragment extends Fragment
             bSend.setEnabled(false);
         }
         if (isVisible()) enableAccountsList(false); //otherwise it is enabled in onResume()
+    }
+
+    public void onStartRescan() {
+        unsync();
         firstBlock = 0;
     }
 
@@ -460,10 +464,17 @@ public class WalletFragment extends Fragment
             } else {
                 sync = getString(R.string.status_synced) + " " + formatter.format(wallet.getBlockChainHeight());
                 ivSynced.setVisibility(View.VISIBLE);
+                setProgress(-1);
             }
         } else {
             sync = getString(R.string.status_wallet_connecting);
             setProgress(101);
+            ivSynced.setVisibility(View.GONE);
+        }
+        if (wallet.isSynchronized()) {
+            onSynced();
+        } else {
+            unsync();
         }
         setProgress(sync);
         // TODO show connected status somewhere

--- a/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
@@ -283,6 +283,10 @@ public class Wallet {
         this.synced = true;
     }
 
+    public void setUnsynchronized() {
+        this.synced = false;
+    }
+
     public static native String getDisplayAmount(long amount);
 
     public static native long getAmountFromString(String amount);

--- a/app/src/main/java/com/m2049r/xmrwallet/service/WalletService.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/service/WalletService.java
@@ -121,8 +121,9 @@ public class WalletService extends Service {
                 Timber.d("newBlock() @ %d with observer %s", height, observer);
                 if (observer != null) {
                     boolean fullRefresh = false;
-                    updateDaemonState(wallet, wallet.isSynchronized() ? height : 0);
-                    if (!wallet.isSynchronized()) {
+                    boolean receivedNewBlock = true;
+                    boolean updatedWalletConnectionStatus = updateDaemonState(wallet, height, receivedNewBlock);
+                    if (updatedWalletConnectionStatus || !wallet.isSynchronized()) {
                         updated = true;
                         // we want to see our transactions as they come in
                         wallet.refreshHistory();
@@ -146,13 +147,13 @@ public class WalletService extends Service {
             updated = true;
         }
 
-        public void refreshed() { // this means it's synced
+        public void refreshed() {
             Timber.d("refreshed()");
             final Wallet wallet = getWallet();
             if (wallet == null) throw new IllegalStateException("No wallet!");
-            wallet.setSynchronized();
-            if (updated) {
-                updateDaemonState(wallet, wallet.getBlockChainHeight());
+            boolean receivedNewBlock = false;
+            boolean updatedWalletConnectionStatus = updateDaemonState(wallet, wallet.getBlockChainHeight(), receivedNewBlock);
+            if (updated || updatedWalletConnectionStatus) {
                 wallet.refreshHistory();
                 if (observer != null) {
                     updated = !observer.onRefreshed(wallet, true);
@@ -164,16 +165,20 @@ public class WalletService extends Service {
     private long lastDaemonStatusUpdate = 0;
     private long daemonHeight = 0;
     private Wallet.ConnectionStatus connectionStatus = Wallet.ConnectionStatus.ConnectionStatus_Disconnected;
-    private static final long STATUS_UPDATE_INTERVAL = 120000; // 120s (blocktime)
+    private static final long STATUS_UPDATE_INTERVAL_SYNCED = 120000; // 120s (blocktime)
+    private static final long STATUS_UPDATE_INTERVAL_SYNCING = 10000; // 10s
 
-    private void updateDaemonState(Wallet wallet, long height) {
+    private boolean updateDaemonState(Wallet wallet, long height, boolean receivedNewBlock) {
+        Wallet.ConnectionStatus startConnectionStatus = connectionStatus;
         long t = System.currentTimeMillis();
-        if (height > 0) { // if we get a height, we are connected
-            daemonHeight = height;
+        if (daemonHeight > 0 && height > 0 && (height > daemonHeight || receivedNewBlock)) {
+            if (height > daemonHeight)
+                daemonHeight = height;
             connectionStatus = Wallet.ConnectionStatus.ConnectionStatus_Connected;
             lastDaemonStatusUpdate = t;
         } else {
-            if (t - lastDaemonStatusUpdate > STATUS_UPDATE_INTERVAL) {
+            long statusUpdateInterval = wallet.isSynchronized() ? STATUS_UPDATE_INTERVAL_SYNCED : STATUS_UPDATE_INTERVAL_SYNCING;
+            if (daemonHeight == 0 || t - lastDaemonStatusUpdate > statusUpdateInterval) {
                 lastDaemonStatusUpdate = t;
                 // these calls really connect to the daemon - wasting time
                 daemonHeight = wallet.getDaemonBlockChainHeight();
@@ -184,6 +189,16 @@ public class WalletService extends Service {
                     connectionStatus = Wallet.ConnectionStatus.ConnectionStatus_Disconnected;
                 }
             }
+        }
+        setWalletSyncState(wallet);
+        return startConnectionStatus != connectionStatus;
+    }
+
+    public void setWalletSyncState(Wallet wallet) {
+        if (daemonHeight > 0 && daemonHeight <= wallet.getBlockChainHeight()) {
+            wallet.setSynchronized();
+        } else {
+            wallet.setUnsynchronized();
         }
     }
 


### PR DESCRIPTION
### The issue

When the client loses its connection to the daemon (phone loses service, or daemon doesn't respond, etc.), the UI displays the "synced" state with green check marks at whatever height the connection is lost:

<p align=center><img src="https://user-images.githubusercontent.com/26468430/160190126-454c5230-c31f-43b7-98f4-d2c97701ab3c.gif" width="40%"></p>



When the client regains connection, the "synced" state remains in the UI, but the displayed height continues jumping forward (the client resumes scanning even though it says "synced"). Also note the "GIVE" button is clickable at this point, which could present other issues I didn't look into:

<p align=center><img src="https://user-images.githubusercontent.com/26468430/160190143-fb655ee4-f106-4f99-9835-6b459f05ab55.gif" width="40%"></p>


### This PR's fix

If the client loses its connection to the daemon, after a bit of a delay, the client will re-enter the "Connecting..." state:

<p align=center><img src="https://user-images.githubusercontent.com/26468430/160190182-4361fc29-4f34-47a0-907c-8383b9d25679.gif" width="40%"></p>

Upon re-connecting to the daemon, it re-enters the "Scanning" state:

<p align=center><img src="https://user-images.githubusercontent.com/26468430/160190207-a797bfc8-7471-4e8c-9953-ed6c5b8f3ea0.gif" width="40%"></p>


### Important note

This PR pairs with [this change](https://github.com/monero-project/monero/commit/8cf95c8f2926fa85c232596d06f17633e7007cd1) to wallet2 on the master branch. That change ensures `refresh()` does not mistakenly set the daemon's height to the scanned blockhain height when the daemon returns a failed a response.

I first noticed this general UI issue when observing behavior background scanning from 0 via 3rd party remote nodes. Turns out 3rd party remote node responses can be super flaky.