### PR TITLE
Adding support for Ledger Nano S Plus

### DIFF
--- a/app/src/main/java/com/btchip/comm/android/BTChipTransportAndroidHID.java
+++ b/app/src/main/java/com/btchip/comm/android/BTChipTransportAndroidHID.java
@@ -78,7 +78,7 @@ public class BTChipTransportAndroidHID implements BTChipTransport {
     }
 
     private static final int VID = 0x2C97;
-    private static final int[] PID_HIDS = {0x0001, 0x0004};
+    private static final int[] PID_HIDS = {0x0001, 0x0004, 0x0005};
 
     private UsbDeviceConnection connection;
     private UsbInterface dongleInterface;

--- a/app/src/main/res/values-cat/strings.xml
+++ b/app/src/main/res/values-cat/strings.xml
@@ -290,7 +290,7 @@
     <string name="menu_language">Idioma</string>
     <string name="language_system_default">Utilitzar Idioma del Sistema</string>
 
-    <string name="fab_restore_ledger">Restablir desde Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restablir desde Ledger Nano</string>
 
     <string name="progress_ledger_progress">Comunicant amb Ledger</string>
     <string name="progress_ledger_confirm">Es requereix confirmació en Ledger!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -286,7 +286,7 @@
     <string name="menu_language">Sprache</string>
     <string name="language_system_default">Benutze Systemsprache</string>
 
-    <string name="fab_restore_ledger">Wallet mit Ledger Nano S wiederherstellen</string>
+    <string name="fab_restore_ledger">Wallet mit Ledger Nano wiederherstellen</string>
 
     <string name="progress_ledger_progress">Kommunikation mit Ledger</string>
     <string name="progress_ledger_confirm">Bestätigung auf Ledger benötigt!</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -283,7 +283,7 @@
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 
-    <string name="fab_restore_ledger">Restore from Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restore from Ledger Nano</string>
 
     <string name="progress_ledger_progress">Communicating with Ledger</string>
     <string name="progress_ledger_confirm">Confirmation on Ledger required!</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -290,7 +290,7 @@
     <string name="menu_language">Lingvo</string>
     <string name="language_system_default">Uzi la sistemlingvon</string>
 
-    <string name="fab_restore_ledger">Restaŭri de Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restaŭri de Ledger Nano</string>
 
     <string name="progress_ledger_progress">Komunikante kun Ledger</string>
     <string name="progress_ledger_confirm">Konfirmo je la Ledger estas postulita!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -273,7 +273,7 @@
     <string name="menu_language">Lenguaje</string>
     <string name="language_system_default">Usar Idioma del Sistema</string>
 
-    <string name="fab_restore_ledger">Restaurar desde Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restaurar desde Ledger Nano</string>
 
     <string name="progress_ledger_progress">Comunicándose con Ledger</string>
     <string name="progress_ledger_confirm">¡Confirmación en Ledger requerida!</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -285,7 +285,7 @@
     <string name="menu_language">Keel</string>
     <string name="language_system_default">Kasuta süsteemi keelt</string>
 
-    <string name="fab_restore_ledger">Taasta seadmelt Ledger Nano S</string>
+    <string name="fab_restore_ledger">Taasta seadmelt Ledger Nano</string>
 
     <string name="progress_ledger_progress">Suhtlen seadmega Ledger</string>
     <string name="progress_ledger_confirm">Seadmelt Ledger on vajalik kinnitus!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -284,7 +284,7 @@
     <string name="tx_subaddress">Sous-adresse</string>
     <string name="generate_address_label_sub">Sous-adresse publique #%1$d: %2$s</string>
 
-    <string name="fab_restore_ledger">Restaurer depuis Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restaurer depuis Ledger Nano</string>
 
     <string name="progress_ledger_progress">Communication avec Ledger</string>
     <string name="progress_ledger_confirm">Confirmation requise sur Ledger !</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -283,7 +283,7 @@
     <string name="menu_language">Nyelv</string>
     <string name="language_system_default">Rendszernyelv használata</string>
 
-    <string name="fab_restore_ledger">Visszaállítás Ledger Nano S-ről</string>
+    <string name="fab_restore_ledger">Visszaállítás Ledger Nano-ről</string>
 
     <string name="progress_ledger_progress">Kommunikáció a Ledgerrel</string>
     <string name="progress_ledger_confirm">Ledgeren való megerősítés szükséges!</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -286,7 +286,7 @@
     <string name="menu_language">Lingua</string>
     <string name="language_system_default">Usa lingua di sistema</string>
 
-    <string name="fab_restore_ledger">Ripristina da Ledger Nano S</string>
+    <string name="fab_restore_ledger">Ripristina da Ledger Nano</string>
 
     <string name="progress_ledger_progress">In comunicazione con Ledger</string>
     <string name="progress_ledger_confirm">Conferma su Ledger richiesta!</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -289,7 +289,7 @@
     <string name="menu_language">言語</string>
     <string name="language_system_default">システムの言語を使う</string>
 
-    <string name="fab_restore_ledger">レッジャーナノSから復元</string>
+    <string name="fab_restore_ledger">レッジャーナノから復元</string>
 
     <string name="progress_ledger_progress">レッジャーと通信中</string>
     <string name="progress_ledger_confirm">レッジャーでの承認が必要です!</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -283,7 +283,7 @@
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 
-    <string name="fab_restore_ledger">Restore from Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restore from Ledger Nano</string>
 
     <string name="progress_ledger_progress">Communicating with Ledger</string>
     <string name="progress_ledger_confirm">Confirmation on Ledger required!</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -281,7 +281,7 @@
     <string name="menu_language">Taal</string>
     <string name="language_system_default">Systeemtaal gebruiken</string>
 
-    <string name="fab_restore_ledger">Herstellen met Ledger Nano S</string>
+    <string name="fab_restore_ledger">Herstellen met Ledger Nano</string>
 
     <string name="progress_ledger_progress">Communiceren met Ledger…</string>
     <string name="progress_ledger_confirm">Bevestiging op Ledger vereist!</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -282,7 +282,7 @@
     <string name="menu_language">Idioma</string>
     <string name="language_system_default">Usar o idioma do sistema</string>
 
-    <string name="fab_restore_ledger">Restaurar da Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restaurar da Ledger Nano</string>
 
     <string name="progress_ledger_progress">Comunicando com a Ledger</string>
     <string name="progress_ledger_confirm">Necessária confirmação na Ledger!</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -285,7 +285,7 @@
     <string name="menu_language">Linguagem</string>
     <string name="language_system_default">Usar linguagem de sistema</string>
 
-    <string name="fab_restore_ledger">Restaurar de Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restaurar de Ledger Nano</string>
 
     <string name="progress_ledger_progress">A comunicar com o Ledger</string>
     <string name="progress_ledger_confirm">Confirmação com Ledger necessária!</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -283,7 +283,7 @@
     <string name="menu_language">Limbă</string>
     <string name="language_system_default">De sistem</string>
 
-    <string name="fab_restore_ledger">Recuperează cu Ledger Nano S</string>
+    <string name="fab_restore_ledger">Recuperează cu Ledger Nano</string>
 
     <string name="progress_ledger_progress">Comunicare cu Ledger</string>
     <string name="progress_ledger_confirm">Confirmare necesară în Ledger!</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -285,7 +285,7 @@
     <string name="menu_language">Язык</string>
     <string name="language_system_default">Использовать язык системы</string>
 
-    <string name="fab_restore_ledger">Восстановление из Ledger Nano S</string>
+    <string name="fab_restore_ledger">Восстановление из Ledger Nano</string>
 
     <string name="progress_ledger_progress">Подключение к Ledger</string>
     <string name="progress_ledger_confirm">Требуется подтверждение в Ledger!</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -282,7 +282,7 @@
     <string name="menu_language">Jazyk</string>
     <string name="language_system_default">Použi jazyk systému</string>
 
-    <string name="fab_restore_ledger">Obnoviť z Ledger Nano S</string>
+    <string name="fab_restore_ledger">Obnoviť z Ledger Nano</string>
 
     <string name="progress_ledger_progress">Komunikácia s Ledger</string>
     <string name="progress_ledger_confirm">Vyžaduje potvrdenie na Ledgeri!</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -292,7 +292,7 @@
     <string name="menu_language">Jezik</string>
     <string name="language_system_default">Koristi sistemski jezik</string>
 
-    <string name="fab_restore_ledger">Povrati iz knjige računa nano S</string>
+    <string name="fab_restore_ledger">Povrati iz knjige računa nano</string>
 
     <string name="progress_ledger_progress">Komunikacija sa knjigom računa</string>
     <string name="progress_ledger_confirm">Potrebna potvrda iz knjige računa!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -274,7 +274,7 @@
     <string name="menu_language">Språk</string>
     <string name="language_system_default">Använd systemets språk</string>
 
-    <string name="fab_restore_ledger">Återställ från Ledger Nano S</string>
+    <string name="fab_restore_ledger">Återställ från Ledger Nano</string>
 
     <string name="progress_ledger_progress">Kommunicerar med Ledger</string>
     <string name="progress_ledger_confirm">Bekräfta på Ledger!</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -285,7 +285,7 @@
     <string name="menu_language">Мова</string>
     <string name="language_system_default">Використовувати мову системи</string>
 
-    <string name="fab_restore_ledger">Відновлення з Ledger Nano S</string>
+    <string name="fab_restore_ledger">Відновлення з Ledger Nano</string>
 
     <string name="progress_ledger_progress">Підключення до Ledger</string>
     <string name="progress_ledger_confirm">Необхідне підтвердження в Ledger!</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -224,7 +224,7 @@
     <string name="generate_address_label_sub">公开子地址#%1$d: %2$s</string>
     <string name="menu_language">语言</string>
     <string name="language_system_default">使用系统默认语言</string>
-    <string name="fab_restore_ledger">通过Ledger Nano S恢复</string>
+    <string name="fab_restore_ledger">通过Ledger Nano 恢复</string>
     <string name="progress_ledger_progress">与Ledger通信中</string>
     <string name="progress_ledger_confirm">请在Ledger设备上确认！</string>
     <string name="progress_ledger_lookahead">子地址检索中</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -281,7 +281,7 @@
     <string name="menu_language">語言</string>
     <string name="language_system_default">使用系統語言</string>
 
-    <string name="fab_restore_ledger">從 Ledger Nano S 回復錢包</string>
+    <string name="fab_restore_ledger">從 Ledger Nano 回復錢包</string>
 
     <string name="progress_ledger_progress">與 Ledger 錢包傳輸資料中</string>
     <string name="progress_ledger_confirm">請在 Ledger 裝置上確認此操作！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,7 +338,7 @@
     <string name="menu_language">Language</string>
     <string name="language_system_default">Use System Language</string>
 
-    <string name="fab_restore_ledger">Restore from Ledger Nano S</string>
+    <string name="fab_restore_ledger">Restore from Ledger Nano</string>
 
     <string name="progress_ledger_progress">Communicating with Ledger</string>
     <string name="progress_ledger_confirm">Confirmation on Ledger required!</string>

--- a/app/src/main/res/xml/usb_device_filter.xml
+++ b/app/src/main/res/xml/usb_device_filter.xml
@@ -11,4 +11,9 @@
         product-id="4"
         vendor-id="11415" />
 
+    <!-- Ledger Nano S Plus HID: VID=0x2C97 PID=0x0005 -->
+    <usb-device
+        product-id="5"
+        vendor-id="11415" />
+
 </resources>


### PR DESCRIPTION
1. Added support for Ledger Nano S Plus
2. Modified "Restore from Ledger Nano S" string to agnostic support of S/S+/X, "Restore from Ledger Nano"

reference: https://github.com/monero-project/monero/pull/8239

Note: Confirmed functionality on Ledger Nano S Plus hardware.
