### PR TITLE
Upgrade to 0.18.0.0 Fluorine Fermi

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -121,7 +121,7 @@ set_target_properties(easylogging PROPERTIES IMPORTED_LOCATION
 
 add_library(unbound STATIC IMPORTED)
 set_target_properties(unbound PROPERTIES IMPORTED_LOCATION
-    ${EXTERNAL_LIBS_DIR}/${ANDROID_ABI}/monero/libunbound.a)
+    ${EXTERNAL_LIBS_DIR}/${ANDROID_ABI}/libunbound.a)
 
 add_library(epee STATIC IMPORTED)
 set_target_properties(epee PROPERTIES IMPORTED_LOCATION

--- a/app/src/main/cpp/monerujo.cpp
+++ b/app/src/main/cpp/monerujo.cpp
@@ -96,7 +96,7 @@ void detachJVM(JNIEnv *jenv, int envStat) {
     }
 }
 
-struct MyWalletListener : Bitmonero::WalletListener {
+struct MyWalletListener : Monero::WalletListener {
     jobject jlistener;
 
     MyWalletListener(JNIEnv *env, jobject aListener) {
@@ -266,8 +266,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_createWalletJ(JNIEnv *env, jobject
     const char *_language = env->GetStringUTFChars(language, nullptr);
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
 
-    Bitmonero::Wallet *wallet =
-            Bitmonero::WalletManagerFactory::getWalletManager()->createWallet(
+    Monero::Wallet *wallet =
+            Monero::WalletManagerFactory::getWalletManager()->createWallet(
                     std::string(_path),
                     std::string(_password),
                     std::string(_language),
@@ -287,8 +287,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_openWalletJ(JNIEnv *env, jobject i
     const char *_password = env->GetStringUTFChars(password, nullptr);
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
 
-    Bitmonero::Wallet *wallet =
-            Bitmonero::WalletManagerFactory::getWalletManager()->openWallet(
+    Monero::Wallet *wallet =
+            Monero::WalletManagerFactory::getWalletManager()->openWallet(
                     std::string(_path),
                     std::string(_password),
                     _networkType);
@@ -310,8 +310,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_recoveryWalletJ(JNIEnv *env, jobje
     const char *_offset = env->GetStringUTFChars(offset, nullptr);
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
 
-    Bitmonero::Wallet *wallet =
-            Bitmonero::WalletManagerFactory::getWalletManager()->recoveryWallet(
+    Monero::Wallet *wallet =
+            Monero::WalletManagerFactory::getWalletManager()->recoveryWallet(
                     std::string(_path),
                     std::string(_password),
                     std::string(_mnemonic),
@@ -344,8 +344,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_createWalletFromKeysJ(JNIEnv *env,
     const char *_viewKeyString = env->GetStringUTFChars(viewKeyString, nullptr);
     const char *_spendKeyString = env->GetStringUTFChars(spendKeyString, nullptr);
 
-    Bitmonero::Wallet *wallet =
-            Bitmonero::WalletManagerFactory::getWalletManager()->createWalletFromKeys(
+    Monero::Wallet *wallet =
+            Monero::WalletManagerFactory::getWalletManager()->createWalletFromKeys(
                     std::string(_path),
                     std::string(_password),
                     std::string(_language),
@@ -381,8 +381,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_createWalletFromDeviceJ(JNIEnv *en
     const char *_deviceName = env->GetStringUTFChars(deviceName, nullptr);
     const char *_subaddressLookahead = env->GetStringUTFChars(subaddressLookahead, nullptr);
 
-    Bitmonero::Wallet *wallet =
-            Bitmonero::WalletManagerFactory::getWalletManager()->createWalletFromDevice(
+    Monero::Wallet *wallet =
+            Monero::WalletManagerFactory::getWalletManager()->createWalletFromDevice(
                     std::string(_path),
                     std::string(_password),
                     _networkType,
@@ -402,7 +402,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_walletExists(JNIEnv *env, jobject 
                                                            jstring path) {
     const char *_path = env->GetStringUTFChars(path, nullptr);
     bool exists =
-            Bitmonero::WalletManagerFactory::getWalletManager()->walletExists(std::string(_path));
+            Monero::WalletManagerFactory::getWalletManager()->walletExists(std::string(_path));
     env->ReleaseStringUTFChars(path, _path);
     return static_cast<jboolean>(exists);
 }
@@ -415,7 +415,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_verifyWalletPassword(JNIEnv *env, 
     const char *_keys_file_name = env->GetStringUTFChars(keys_file_name, nullptr);
     const char *_password = env->GetStringUTFChars(password, nullptr);
     bool passwordOk =
-            Bitmonero::WalletManagerFactory::getWalletManager()->verifyWalletPassword(
+            Monero::WalletManagerFactory::getWalletManager()->verifyWalletPassword(
                     std::string(_keys_file_name), std::string(_password), watch_only);
     env->ReleaseStringUTFChars(keys_file_name, _keys_file_name);
     env->ReleaseStringUTFChars(password, _password);
@@ -429,8 +429,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_queryWalletDeviceJ(JNIEnv *env, jo
                                                                  jstring password) {
     const char *_keys_file_name = env->GetStringUTFChars(keys_file_name, nullptr);
     const char *_password = env->GetStringUTFChars(password, nullptr);
-    Bitmonero::Wallet::Device device_type;
-    bool ok = Bitmonero::WalletManagerFactory::getWalletManager()->
+    Monero::Wallet::Device device_type;
+    bool ok = Monero::WalletManagerFactory::getWalletManager()->
             queryWalletDevice(device_type, std::string(_keys_file_name), std::string(_password));
     env->ReleaseStringUTFChars(keys_file_name, _keys_file_name);
     env->ReleaseStringUTFChars(password, _password);
@@ -445,7 +445,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_findWallets(JNIEnv *env, jobject i
                                                           jstring path) {
     const char *_path = env->GetStringUTFChars(path, nullptr);
     std::vector<std::string> walletPaths =
-            Bitmonero::WalletManagerFactory::getWalletManager()->findWallets(std::string(_path));
+            Monero::WalletManagerFactory::getWalletManager()->findWallets(std::string(_path));
     env->ReleaseStringUTFChars(path, _path);
     return cpp2java(env, walletPaths);
 }
@@ -456,7 +456,7 @@ JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_setDaemonAddressJ(JNIEnv *env, jobject instance,
                                                                 jstring address) {
     const char *_address = env->GetStringUTFChars(address, nullptr);
-    Bitmonero::WalletManagerFactory::getWalletManager()->setDaemonAddress(std::string(_address));
+    Monero::WalletManagerFactory::getWalletManager()->setDaemonAddress(std::string(_address));
     env->ReleaseStringUTFChars(address, _address);
 }
 
@@ -466,40 +466,40 @@ Java_com_m2049r_xmrwallet_model_WalletManager_getDaemonVersion(JNIEnv *env,
                                                                jobject instance) {
     uint32_t version;
     bool isConnected =
-            Bitmonero::WalletManagerFactory::getWalletManager()->connected(&version);
+            Monero::WalletManagerFactory::getWalletManager()->connected(&version);
     if (!isConnected) version = 0;
     return version;
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_getBlockchainHeight(JNIEnv *env, jobject instance) {
-    return Bitmonero::WalletManagerFactory::getWalletManager()->blockchainHeight();
+    return Monero::WalletManagerFactory::getWalletManager()->blockchainHeight();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_getBlockchainTargetHeight(JNIEnv *env,
                                                                         jobject instance) {
-    return Bitmonero::WalletManagerFactory::getWalletManager()->blockchainTargetHeight();
+    return Monero::WalletManagerFactory::getWalletManager()->blockchainTargetHeight();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_getNetworkDifficulty(JNIEnv *env, jobject instance) {
-    return Bitmonero::WalletManagerFactory::getWalletManager()->networkDifficulty();
+    return Monero::WalletManagerFactory::getWalletManager()->networkDifficulty();
 }
 
 JNIEXPORT jdouble JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_getMiningHashRate(JNIEnv *env, jobject instance) {
-    return Bitmonero::WalletManagerFactory::getWalletManager()->miningHashRate();
+    return Monero::WalletManagerFactory::getWalletManager()->miningHashRate();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_getBlockTarget(JNIEnv *env, jobject instance) {
-    return Bitmonero::WalletManagerFactory::getWalletManager()->blockTarget();
+    return Monero::WalletManagerFactory::getWalletManager()->blockTarget();
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_isMining(JNIEnv *env, jobject instance) {
-    return static_cast<jboolean>(Bitmonero::WalletManagerFactory::getWalletManager()->isMining());
+    return static_cast<jboolean>(Monero::WalletManagerFactory::getWalletManager()->isMining());
 }
 
 JNIEXPORT jboolean JNICALL
@@ -509,7 +509,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_startMining(JNIEnv *env, jobject i
                                                           jboolean ignore_battery) {
     const char *_address = env->GetStringUTFChars(address, nullptr);
     bool success =
-            Bitmonero::WalletManagerFactory::getWalletManager()->startMining(std::string(_address),
+            Monero::WalletManagerFactory::getWalletManager()->startMining(std::string(_address),
                                                                              background_mining,
                                                                              ignore_battery);
     env->ReleaseStringUTFChars(address, _address);
@@ -518,7 +518,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_startMining(JNIEnv *env, jobject i
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_stopMining(JNIEnv *env, jobject instance) {
-    return static_cast<jboolean>(Bitmonero::WalletManagerFactory::getWalletManager()->stopMining());
+    return static_cast<jboolean>(Monero::WalletManagerFactory::getWalletManager()->stopMining());
 }
 
 JNIEXPORT jstring JNICALL
@@ -528,7 +528,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_resolveOpenAlias(JNIEnv *env, jobj
     const char *_address = env->GetStringUTFChars(address, nullptr);
     bool _dnssec_valid = (bool) dnssec_valid;
     std::string resolvedAlias =
-            Bitmonero::WalletManagerFactory::getWalletManager()->resolveOpenAlias(
+            Monero::WalletManagerFactory::getWalletManager()->resolveOpenAlias(
                     std::string(_address),
                     _dnssec_valid);
     env->ReleaseStringUTFChars(address, _address);
@@ -540,7 +540,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_setProxy(JNIEnv *env, jobject inst
                                                        jstring address) {
     const char *_address = env->GetStringUTFChars(address, nullptr);
     bool rc =
-            Bitmonero::WalletManagerFactory::getWalletManager()->setProxy(std::string(_address));
+            Monero::WalletManagerFactory::getWalletManager()->setProxy(std::string(_address));
     env->ReleaseStringUTFChars(address, _address);
     return rc;
 }
@@ -551,8 +551,8 @@ Java_com_m2049r_xmrwallet_model_WalletManager_setProxy(JNIEnv *env, jobject inst
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_closeJ(JNIEnv *env, jobject instance,
                                                      jobject walletInstance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, walletInstance);
-    bool closeSuccess = Bitmonero::WalletManagerFactory::getWalletManager()->closeWallet(wallet,
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, walletInstance);
+    bool closeSuccess = Monero::WalletManagerFactory::getWalletManager()->closeWallet(wallet,
                                                                                          false);
     if (closeSuccess) {
         MyWalletListener *walletListener = getHandle<MyWalletListener>(env, walletInstance,
@@ -576,7 +576,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_closeJ(JNIEnv *env, jobject instan
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getSeed(JNIEnv *env, jobject instance, jstring seedOffset) {
     const char *_seedOffset = env->GetStringUTFChars(seedOffset, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     jstring seed = env->NewStringUTF(wallet->seed(std::string(_seedOffset)).c_str());
     env->ReleaseStringUTFChars(seedOffset, _seedOffset);
     return seed;
@@ -584,7 +584,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getSeed(JNIEnv *env, jobject instance, js
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getSeedLanguage(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(wallet->getSeedLanguage().c_str());
 }
 
@@ -592,14 +592,14 @@ JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setSeedLanguage(JNIEnv *env, jobject instance,
                                                        jstring language) {
     const char *_language = env->GetStringUTFChars(language, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->setSeedLanguage(std::string(_language));
     env->ReleaseStringUTFChars(language, _language);
 }
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getStatusJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->status();
 }
 
@@ -615,7 +615,7 @@ jobject newWalletStatusInstance(JNIEnv *env, int status, const std::string &erro
 
 JNIEXPORT jobject JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_statusWithErrorString(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     int status;
     std::string errorString;
@@ -628,7 +628,7 @@ JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setPassword(JNIEnv *env, jobject instance,
                                                    jstring password) {
     const char *_password = env->GetStringUTFChars(password, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     bool success = wallet->setPassword(std::string(_password));
     env->ReleaseStringUTFChars(password, _password);
     return static_cast<jboolean>(success);
@@ -638,20 +638,20 @@ JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getAddressJ(JNIEnv *env, jobject instance,
                                                    jint accountIndex,
                                                    jint addressIndex) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(
             wallet->address((uint32_t) accountIndex, (uint32_t) addressIndex).c_str());
 }
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getPath(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(wallet->path().c_str());
 }
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_nettype(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->nettype();
 }
 
@@ -662,7 +662,7 @@ JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getIntegratedAddress(JNIEnv *env, jobject instance,
                                                             jstring payment_id) {
     const char *_payment_id = env->GetStringUTFChars(payment_id, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     std::string address = wallet->integratedAddress(_payment_id);
     env->ReleaseStringUTFChars(payment_id, _payment_id);
     return env->NewStringUTF(address.c_str());
@@ -670,13 +670,13 @@ Java_com_m2049r_xmrwallet_model_Wallet_getIntegratedAddress(JNIEnv *env, jobject
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getSecretViewKey(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(wallet->secretViewKey().c_str());
 }
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getSecretSpendKey(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(wallet->secretSpendKey().c_str());
 }
 
@@ -684,7 +684,7 @@ JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_store(JNIEnv *env, jobject instance,
                                              jstring path) {
     const char *_path = env->GetStringUTFChars(path, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     bool success = wallet->store(std::string(_path));
     if (!success) {
         LOGE("store() %s", wallet->errorString().c_str());
@@ -695,7 +695,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_store(JNIEnv *env, jobject instance,
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getFilename(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return env->NewStringUTF(wallet->filename().c_str());
 }
 
@@ -709,7 +709,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_initJ(JNIEnv *env, jobject instance,
     const char *_daemon_address = env->GetStringUTFChars(daemon_address, nullptr);
     const char *_daemon_username = env->GetStringUTFChars(daemon_username, nullptr);
     const char *_daemon_password = env->GetStringUTFChars(daemon_password, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     bool status = wallet->init(_daemon_address, (uint64_t) upper_transaction_size_limit,
                                _daemon_username,
                                _daemon_password);
@@ -724,13 +724,13 @@ Java_com_m2049r_xmrwallet_model_Wallet_initJ(JNIEnv *env, jobject instance,
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setRestoreHeight(JNIEnv *env, jobject instance,
                                                         jlong height) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->setRefreshFromBlockHeight((uint64_t) height);
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getRestoreHeight(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->getRefreshFromBlockHeight();
 }
 
@@ -739,7 +739,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getRestoreHeight(JNIEnv *env, jobject ins
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getConnectionStatusJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->connected();
 }
 //TODO virtual void setTrustedDaemon(bool arg) = 0;
@@ -749,7 +749,7 @@ JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setProxy(JNIEnv *env, jobject instance,
                                                 jstring address) {
     const char *_address = env->GetStringUTFChars(address, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     bool rc = wallet->setProxy(std::string(_address));
     env->ReleaseStringUTFChars(address, _address);
     return rc;
@@ -758,71 +758,71 @@ Java_com_m2049r_xmrwallet_model_Wallet_setProxy(JNIEnv *env, jobject instance,
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getBalance(JNIEnv *env, jobject instance,
                                                   jint accountIndex) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->balance((uint32_t) accountIndex);
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getBalanceAll(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->balanceAll();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getUnlockedBalance(JNIEnv *env, jobject instance,
                                                           jint accountIndex) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->unlockedBalance((uint32_t) accountIndex);
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getUnlockedBalanceAll(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->unlockedBalanceAll();
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_isWatchOnly(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return static_cast<jboolean>(wallet->watchOnly());
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getBlockChainHeight(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->blockChainHeight();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getApproximateBlockChainHeight(JNIEnv *env,
                                                                       jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->approximateBlockChainHeight();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getDaemonBlockChainHeight(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->daemonBlockChainHeight();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getDaemonBlockChainTargetHeight(JNIEnv *env,
                                                                        jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->daemonBlockChainTargetHeight();
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_isSynchronizedJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return static_cast<jboolean>(wallet->synchronized());
 }
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getDeviceTypeJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
-    Bitmonero::Wallet::Device device_type = wallet->getDeviceType();
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
+    Monero::Wallet::Device device_type = wallet->getDeviceType();
     return static_cast<jint>(device_type);
 }
 
@@ -856,14 +856,14 @@ Java_com_m2049r_xmrwallet_util_KeyStoreHelper_slowHash(JNIEnv *env, jclass clazz
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getDisplayAmount(JNIEnv *env, jclass clazz,
                                                         jlong amount) {
-    return env->NewStringUTF(Bitmonero::Wallet::displayAmount(amount).c_str());
+    return env->NewStringUTF(Monero::Wallet::displayAmount(amount).c_str());
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getAmountFromString(JNIEnv *env, jclass clazz,
                                                            jstring amount) {
     const char *_amount = env->GetStringUTFChars(amount, nullptr);
-    uint64_t x = Bitmonero::Wallet::amountFromString(_amount);
+    uint64_t x = Monero::Wallet::amountFromString(_amount);
     env->ReleaseStringUTFChars(amount, _amount);
     return x;
 }
@@ -871,19 +871,19 @@ Java_com_m2049r_xmrwallet_model_Wallet_getAmountFromString(JNIEnv *env, jclass c
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getAmountFromDouble(JNIEnv *env, jclass clazz,
                                                            jdouble amount) {
-    return Bitmonero::Wallet::amountFromDouble(amount);
+    return Monero::Wallet::amountFromDouble(amount);
 }
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_generatePaymentId(JNIEnv *env, jclass clazz) {
-    return env->NewStringUTF(Bitmonero::Wallet::genPaymentId().c_str());
+    return env->NewStringUTF(Monero::Wallet::genPaymentId().c_str());
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_isPaymentIdValid(JNIEnv *env, jclass clazz,
                                                         jstring payment_id) {
     const char *_payment_id = env->GetStringUTFChars(payment_id, nullptr);
-    bool isValid = Bitmonero::Wallet::paymentIdValid(_payment_id);
+    bool isValid = Monero::Wallet::paymentIdValid(_payment_id);
     env->ReleaseStringUTFChars(payment_id, _payment_id);
     return static_cast<jboolean>(isValid);
 }
@@ -893,7 +893,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_isAddressValid(JNIEnv *env, jclass clazz,
                                                       jstring address, jint networkType) {
     const char *_address = env->GetStringUTFChars(address, nullptr);
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
-    bool isValid = Bitmonero::Wallet::addressValid(_address, _networkType);
+    bool isValid = Monero::Wallet::addressValid(_address, _networkType);
     env->ReleaseStringUTFChars(address, _address);
     return static_cast<jboolean>(isValid);
 }
@@ -904,37 +904,37 @@ Java_com_m2049r_xmrwallet_model_Wallet_getPaymentIdFromAddress(JNIEnv *env, jcla
                                                                jint networkType) {
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
     const char *_address = env->GetStringUTFChars(address, nullptr);
-    std::string payment_id = Bitmonero::Wallet::paymentIdFromAddress(_address, _networkType);
+    std::string payment_id = Monero::Wallet::paymentIdFromAddress(_address, _networkType);
     env->ReleaseStringUTFChars(address, _address);
     return env->NewStringUTF(payment_id.c_str());
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getMaximumAllowedAmount(JNIEnv *env, jclass clazz) {
-    return Bitmonero::Wallet::maximumAllowedAmount();
+    return Monero::Wallet::maximumAllowedAmount();
 }
 
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_startRefresh(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->startRefresh();
 }
 
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_pauseRefresh(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->pauseRefresh();
 }
 
 JNIEXPORT jboolean JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_refresh(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return static_cast<jboolean>(wallet->refresh());
 }
 
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_refreshAsync(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->refreshAsync();
 }
 
@@ -943,7 +943,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_refreshAsync(JNIEnv *env, jobject instanc
 //virtual void rescanBlockchainAsync() = 0;
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_rescanBlockchainAsyncJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->rescanBlockchainAsync();
 }
 
@@ -960,11 +960,11 @@ Java_com_m2049r_xmrwallet_model_Wallet_createTransactionJ(JNIEnv *env, jobject i
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, nullptr);
     const char *_payment_id = env->GetStringUTFChars(payment_id, nullptr);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::PendingTransaction::Priority _priority =
+            static_cast<Monero::PendingTransaction::Priority>(priority);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
-    Bitmonero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
+    Monero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
                                                                   amount, (uint32_t) mixin_count,
                                                                   _priority,
                                                                   (uint32_t) accountIndex);
@@ -983,13 +983,13 @@ Java_com_m2049r_xmrwallet_model_Wallet_createSweepTransaction(JNIEnv *env, jobje
 
     const char *_dst_addr = env->GetStringUTFChars(dst_addr, nullptr);
     const char *_payment_id = env->GetStringUTFChars(payment_id, nullptr);
-    Bitmonero::PendingTransaction::Priority _priority =
-            static_cast<Bitmonero::PendingTransaction::Priority>(priority);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::PendingTransaction::Priority _priority =
+            static_cast<Monero::PendingTransaction::Priority>(priority);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     Monero::optional<uint64_t> empty;
 
-    Bitmonero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
+    Monero::PendingTransaction *tx = wallet->createTransaction(_dst_addr, _payment_id,
                                                                   empty, (uint32_t) mixin_count,
                                                                   _priority,
                                                                   (uint32_t) accountIndex);
@@ -1002,8 +1002,8 @@ Java_com_m2049r_xmrwallet_model_Wallet_createSweepTransaction(JNIEnv *env, jobje
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_createSweepUnmixableTransactionJ(JNIEnv *env,
                                                                         jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
-    Bitmonero::PendingTransaction *tx = wallet->createSweepUnmixableTransaction();
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
+    Monero::PendingTransaction *tx = wallet->createSweepUnmixableTransaction();
     return reinterpret_cast<jlong>(tx);
 }
 
@@ -1013,9 +1013,9 @@ Java_com_m2049r_xmrwallet_model_Wallet_createSweepUnmixableTransactionJ(JNIEnv *
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_disposeTransaction(JNIEnv *env, jobject instance,
                                                           jobject pendingTransaction) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
-    Bitmonero::PendingTransaction *_pendingTransaction =
-            getHandle<Bitmonero::PendingTransaction>(env, pendingTransaction);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
+    Monero::PendingTransaction *_pendingTransaction =
+            getHandle<Monero::PendingTransaction>(env, pendingTransaction);
     wallet->disposeTransaction(_pendingTransaction);
 }
 
@@ -1026,7 +1026,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_disposeTransaction(JNIEnv *env, jobject i
 //virtual TransactionHistory * history() const = 0;
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getHistoryJ(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return reinterpret_cast<jlong>(wallet->history());
 }
 
@@ -1035,7 +1035,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getHistoryJ(JNIEnv *env, jobject instance
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setListenerJ(JNIEnv *env, jobject instance,
                                                     jobject javaListener) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->setListener(nullptr); // clear old listener
     // delete old listener
     MyWalletListener *oldListener = getHandle<MyWalletListener>(env, instance,
@@ -1056,13 +1056,13 @@ Java_com_m2049r_xmrwallet_model_Wallet_setListenerJ(JNIEnv *env, jobject instanc
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getDefaultMixin(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->defaultMixin();
 }
 
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_setDefaultMixin(JNIEnv *env, jobject instance, jint mixin) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return wallet->setDefaultMixin(mixin);
 }
 
@@ -1073,7 +1073,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_setUserNote(JNIEnv *env, jobject instance
     const char *_txid = env->GetStringUTFChars(txid, nullptr);
     const char *_note = env->GetStringUTFChars(note, nullptr);
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     bool success = wallet->setUserNote(_txid, _note);
 
@@ -1089,7 +1089,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getUserNote(JNIEnv *env, jobject instance
 
     const char *_txid = env->GetStringUTFChars(txid, nullptr);
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     std::string note = wallet->getUserNote(_txid);
 
@@ -1103,7 +1103,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getTxKey(JNIEnv *env, jobject instance,
 
     const char *_txid = env->GetStringUTFChars(txid, nullptr);
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     std::string txKey = wallet->getTxKey(_txid);
 
@@ -1118,7 +1118,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_addAccount(JNIEnv *env, jobject instance,
 
     const char *_label = env->GetStringUTFChars(label, nullptr);
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->addSubaddressAccount(_label);
 
     env->ReleaseStringUTFChars(label, _label);
@@ -1129,7 +1129,7 @@ JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getSubaddressLabel(JNIEnv *env, jobject instance,
                                                           jint accountIndex, jint addressIndex) {
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
 
     std::string label = wallet->getSubaddressLabel((uint32_t) accountIndex,
                                                    (uint32_t) addressIndex);
@@ -1145,7 +1145,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_setSubaddressLabel(JNIEnv *env, jobject i
 
     const char *_label = env->GetStringUTFChars(label, nullptr);
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->setSubaddressLabel(accountIndex, addressIndex, _label);
 
     env->ReleaseStringUTFChars(label, _label);
@@ -1154,7 +1154,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_setSubaddressLabel(JNIEnv *env, jobject i
 // virtual size_t numSubaddressAccounts() const = 0;
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getNumAccounts(JNIEnv *env, jobject instance) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return static_cast<jint>(wallet->numSubaddressAccounts());
 }
 
@@ -1162,7 +1162,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getNumAccounts(JNIEnv *env, jobject insta
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_getNumSubaddresses(JNIEnv *env, jobject instance,
                                                           jint accountIndex) {
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     return static_cast<jint>(wallet->numSubaddresses(accountIndex));
 }
 
@@ -1173,7 +1173,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_addSubaddress(JNIEnv *env, jobject instan
                                                      jstring label) {
 
     const char *_label = env->GetStringUTFChars(label, nullptr);
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->addSubaddress(accountIndex, _label);
     env->ReleaseStringUTFChars(label, _label);
 }
@@ -1182,7 +1182,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_addSubaddress(JNIEnv *env, jobject instan
 Java_com_m2049r_xmrwallet_model_Wallet_getLastSubaddress(JNIEnv *env, jobject instance,
                                                          jint accountIndex) {
 
-    Bitmonero::Wallet *wallet = getHandle<Bitmonero::Wallet>(env, instance);
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     size_t num = wallet->numSubaddresses(accountIndex);
     //wallet->subaddress()->getAll()[num]->getAddress().c_str()
     Monero::Subaddress *s = wallet->subaddress();
@@ -1201,7 +1201,7 @@ Java_com_m2049r_xmrwallet_model_Wallet_getLastSubaddress(JNIEnv *env, jobject in
 // TransactionHistory
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_TransactionHistory_getCount(JNIEnv *env, jobject instance) {
-    Bitmonero::TransactionHistory *history = getHandle<Bitmonero::TransactionHistory>(env,
+    Monero::TransactionHistory *history = getHandle<Monero::TransactionHistory>(env,
                                                                                       instance);
     return history->count();
 }
@@ -1215,8 +1215,8 @@ jobject newTransferInstance(JNIEnv *env, uint64_t amount, const std::string &add
     return transfer;
 }
 
-jobject newTransferList(JNIEnv *env, Bitmonero::TransactionInfo *info) {
-    const std::vector<Bitmonero::TransactionInfo::Transfer> &transfers = info->transfers();
+jobject newTransferList(JNIEnv *env, Monero::TransactionInfo *info) {
+    const std::vector<Monero::TransactionInfo::Transfer> &transfers = info->transfers();
     if (transfers.empty()) { // don't create empty Lists
         return nullptr;
     }
@@ -1227,7 +1227,7 @@ jobject newTransferList(JNIEnv *env, Bitmonero::TransactionInfo *info) {
     jobject result = env->NewObject(class_ArrayList, java_util_ArrayList_,
                                     static_cast<jint> (transfers.size()));
     // create Transfer objects and stick them in the List
-    for (const Bitmonero::TransactionInfo::Transfer &s: transfers) {
+    for (const Monero::TransactionInfo::Transfer &s: transfers) {
         jobject element = newTransferInstance(env, s.amount, s.address);
         env->CallBooleanMethod(result, java_util_ArrayList_add, element);
         env->DeleteLocalRef(element);
@@ -1235,7 +1235,7 @@ jobject newTransferList(JNIEnv *env, Bitmonero::TransactionInfo *info) {
     return result;
 }
 
-jobject newTransactionInfo(JNIEnv *env, Bitmonero::TransactionInfo *info) {
+jobject newTransactionInfo(JNIEnv *env, Monero::TransactionInfo *info) {
     jmethodID c = env->GetMethodID(class_TransactionInfo, "<init>",
                                    "(IZZJJJLjava/lang/String;JLjava/lang/String;IIJLjava/lang/String;Ljava/util/List;)V");
     jobject transfers = newTransferList(env, info);
@@ -1243,7 +1243,7 @@ jobject newTransactionInfo(JNIEnv *env, Bitmonero::TransactionInfo *info) {
     jstring _paymentId = env->NewStringUTF(info->paymentId().c_str());
     jstring _label = env->NewStringUTF(info->label().c_str());
     uint32_t subaddrIndex = 0;
-    if (info->direction() == Bitmonero::TransactionInfo::Direction_In)
+    if (info->direction() == Monero::TransactionInfo::Direction_In)
         subaddrIndex = *(info->subaddrIndex().begin());
     jobject result = env->NewObject(class_TransactionInfo, c,
                                     info->direction(),
@@ -1269,7 +1269,7 @@ jobject newTransactionInfo(JNIEnv *env, Bitmonero::TransactionInfo *info) {
 #include <stdio.h>
 #include <stdlib.h>
 
-jobject cpp2java(JNIEnv *env, const std::vector<Bitmonero::TransactionInfo *> &vector) {
+jobject cpp2java(JNIEnv *env, const std::vector<Monero::TransactionInfo *> &vector) {
 
     jmethodID java_util_ArrayList_ = env->GetMethodID(class_ArrayList, "<init>", "(I)V");
     jmethodID java_util_ArrayList_add = env->GetMethodID(class_ArrayList, "add",
@@ -1277,7 +1277,7 @@ jobject cpp2java(JNIEnv *env, const std::vector<Bitmonero::TransactionInfo *> &v
 
     jobject arrayList = env->NewObject(class_ArrayList, java_util_ArrayList_,
                                        static_cast<jint> (vector.size()));
-    for (Bitmonero::TransactionInfo *s: vector) {
+    for (Monero::TransactionInfo *s: vector) {
         jobject info = newTransactionInfo(env, s);
         env->CallBooleanMethod(arrayList, java_util_ArrayList_add, info);
         env->DeleteLocalRef(info);
@@ -1287,7 +1287,7 @@ jobject cpp2java(JNIEnv *env, const std::vector<Bitmonero::TransactionInfo *> &v
 
 JNIEXPORT jobject JNICALL
 Java_com_m2049r_xmrwallet_model_TransactionHistory_refreshJ(JNIEnv *env, jobject instance) {
-    Bitmonero::TransactionHistory *history = getHandle<Bitmonero::TransactionHistory>(env,
+    Monero::TransactionHistory *history = getHandle<Monero::TransactionHistory>(env,
                                                                                       instance);
     history->refresh();
     return cpp2java(env, history->getAll());
@@ -1297,13 +1297,13 @@ Java_com_m2049r_xmrwallet_model_TransactionHistory_refreshJ(JNIEnv *env, jobject
 
 JNIEXPORT jint JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getStatusJ(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return tx->status();
 }
 
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getErrorString(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return env->NewStringUTF(tx->errorString().c_str());
 }
 
@@ -1314,7 +1314,7 @@ Java_com_m2049r_xmrwallet_model_PendingTransaction_commit(JNIEnv *env, jobject i
 
     const char *_filename = env->GetStringUTFChars(filename, nullptr);
 
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     bool success = tx->commit(_filename, overwrite);
 
     env->ReleaseStringUTFChars(filename, _filename);
@@ -1324,26 +1324,26 @@ Java_com_m2049r_xmrwallet_model_PendingTransaction_commit(JNIEnv *env, jobject i
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getAmount(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return tx->amount();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getDust(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return tx->dust();
 }
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getFee(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return tx->fee();
 }
 
 // TODO this returns a vector of strings - deal with this later - for now return first one
 JNIEXPORT jstring JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getFirstTxIdJ(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     std::vector<std::string> txids = tx->txid();
     if (!txids.empty())
         return env->NewStringUTF(txids.front().c_str());
@@ -1353,12 +1353,12 @@ Java_com_m2049r_xmrwallet_model_PendingTransaction_getFirstTxIdJ(JNIEnv *env, jo
 
 JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_PendingTransaction_getTxCount(JNIEnv *env, jobject instance) {
-    Bitmonero::PendingTransaction *tx = getHandle<Bitmonero::PendingTransaction>(env, instance);
+    Monero::PendingTransaction *tx = getHandle<Monero::PendingTransaction>(env, instance);
     return tx->txCount();
 }
 
 
-// these are all in Bitmonero::Wallet - which I find wrong, so they are here!
+// these are all in Monero::Wallet - which I find wrong, so they are here!
 //static void init(const char *argv0, const char *default_log_base_name);
 //static void debug(const std::string &category, const std::string &str);
 //static void info(const std::string &category, const std::string &str);
@@ -1372,7 +1372,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_initLogger(JNIEnv *env, jclass cla
     const char *_argv0 = env->GetStringUTFChars(argv0, nullptr);
     const char *_default_log_base_name = env->GetStringUTFChars(default_log_base_name, nullptr);
 
-    Bitmonero::Wallet::init(_argv0, _default_log_base_name);
+    Monero::Wallet::init(_argv0, _default_log_base_name);
 
     env->ReleaseStringUTFChars(argv0, _argv0);
     env->ReleaseStringUTFChars(default_log_base_name, _default_log_base_name);
@@ -1385,7 +1385,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_logDebug(JNIEnv *env, jclass clazz
     const char *_category = env->GetStringUTFChars(category, nullptr);
     const char *_message = env->GetStringUTFChars(message, nullptr);
 
-    Bitmonero::Wallet::debug(_category, _message);
+    Monero::Wallet::debug(_category, _message);
 
     env->ReleaseStringUTFChars(category, _category);
     env->ReleaseStringUTFChars(message, _message);
@@ -1398,7 +1398,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_logInfo(JNIEnv *env, jclass clazz,
     const char *_category = env->GetStringUTFChars(category, nullptr);
     const char *_message = env->GetStringUTFChars(message, nullptr);
 
-    Bitmonero::Wallet::info(_category, _message);
+    Monero::Wallet::info(_category, _message);
 
     env->ReleaseStringUTFChars(category, _category);
     env->ReleaseStringUTFChars(message, _message);
@@ -1411,7 +1411,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_logWarning(JNIEnv *env, jclass cla
     const char *_category = env->GetStringUTFChars(category, nullptr);
     const char *_message = env->GetStringUTFChars(message, nullptr);
 
-    Bitmonero::Wallet::warning(_category, _message);
+    Monero::Wallet::warning(_category, _message);
 
     env->ReleaseStringUTFChars(category, _category);
     env->ReleaseStringUTFChars(message, _message);
@@ -1424,7 +1424,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_logError(JNIEnv *env, jclass clazz
     const char *_category = env->GetStringUTFChars(category, nullptr);
     const char *_message = env->GetStringUTFChars(message, nullptr);
 
-    Bitmonero::Wallet::error(_category, _message);
+    Monero::Wallet::error(_category, _message);
 
     env->ReleaseStringUTFChars(category, _category);
     env->ReleaseStringUTFChars(message, _message);
@@ -1433,7 +1433,7 @@ Java_com_m2049r_xmrwallet_model_WalletManager_logError(JNIEnv *env, jclass clazz
 JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_setLogLevel(JNIEnv *env, jclass clazz,
                                                           jint level) {
-    Bitmonero::WalletManagerFactory::setLogLevel(level);
+    Monero::WalletManagerFactory::setLogLevel(level);
 }
 
 JNIEXPORT jstring JNICALL

--- a/external-libs/android32.Dockerfile
+++ b/external-libs/android32.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/android
 ENV ANDROID_SDK_REVISION 4333796
 ENV ANDROID_SDK_HASH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
+    && curl -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && echo "${ANDROID_SDK_HASH}  sdk-tools-linux-${ANDROID_SDK_REVISION}.zip" | sha256sum -c \
     && unzip sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && rm -f sdk-tools-linux-${ANDROID_SDK_REVISION}.zip
@@ -16,7 +16,7 @@ RUN set -x \
 ENV ANDROID_NDK_REVISION 17c
 ENV ANDROID_NDK_HASH 3f541adbd0330a9205ba12697f6d04ec90752c53d6b622101a2a8a856e816589
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
+    && curl -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && echo "${ANDROID_NDK_HASH}  android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip" | sha256sum -c \
     && unzip android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && rm -f android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip
@@ -26,7 +26,7 @@ ENV ANDROID_SDK_ROOT ${WORKDIR}/tools
 ENV ANDROID_NDK_ROOT ${WORKDIR}/android-ndk-r${ANDROID_NDK_REVISION}
 ENV PREFIX /opt/android/prefix
 
-ENV TOOLCHAIN_DIR ${WORKDIR}/toolchain-
+ENV TOOLCHAIN_DIR ${WORKDIR}/toolchain
 RUN set -x \
     && ${ANDROID_NDK_ROOT}/build/tools/make_standalone_toolchain.py \
          --arch arm \
@@ -39,7 +39,7 @@ ARG CMAKE_VERSION=3.14.6
 ARG CMAKE_HASH=82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd
 RUN set -x \
     && cd /usr \
-    && curl -L -s -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
+    && curl -L -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && echo "${CMAKE_HASH}  cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c \
     && tar -xzf /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && rm -f /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
@@ -50,7 +50,7 @@ ARG BOOST_VERSION=1_70_0
 ARG BOOST_VERSION_DOT=1.70.0
 ARG BOOST_HASH=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 RUN set -x \
-    && curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+    && curl -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
     && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
     && tar -xvf boost_${BOOST_VERSION}.tar.bz2 \
     && rm -f boost_${BOOST_VERSION}.tar.bz2 \
@@ -60,18 +60,18 @@ RUN set -x \
 ENV HOST_PATH $PATH
 ENV PATH $TOOLCHAIN_DIR/arm-linux-androideabi/bin:$TOOLCHAIN_DIR/bin:$PATH
 
-ARG NPROC=1
+ARG NPROC=4
 
 # Build iconv for lib boost locale
 ENV ICONV_VERSION 1.16
 ENV ICONV_HASH e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 RUN set -x \
-    && curl -s -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
+    && curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
     && echo "${ICONV_HASH}  libiconv-${ICONV_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf libiconv-${ICONV_VERSION}.tar.gz \
     && rm -f libiconv-${ICONV_VERSION}.tar.gz \
     && cd libiconv-${ICONV_VERSION} \
-    && CC=arm-linux-androideabi-clang CXX=arm-linux-androideabi-clang++ ./configure --build=x86_64-linux-gnu --host=arm-linux-androideabi --prefix=${PREFIX} --disable-rpath \
+    && CC=clang CXX=clang++ ./configure --build=x86_64-linux-gnu --host=arm-linux-androideabi --prefix=${PREFIX} --disable-rpath \
     && make -j${NPROC} && make install
 
 ## Build BOOST
@@ -79,13 +79,11 @@ RUN set -x \
     && cd boost_${BOOST_VERSION} \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
-#Note : we build openssl because the default lacks DSA1
-
 # download, configure and make Zlib
 ENV ZLIB_VERSION 1.2.12
 ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
-    && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
+    && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf zlib-${ZLIB_VERSION}.tar.gz \
     && rm zlib-${ZLIB_VERSION}.tar.gz \
@@ -94,23 +92,24 @@ RUN set -x \
     && make -j${NPROC}
 
 # open ssl
-ARG OPENSSL_VERSION=1.0.2p
-ARG OPENSSL_HASH=50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
+ARG OPENSSL_VERSION=3.0.5
+ARG OPENSSL_HASH=aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
+# openssl explicitly demands to be built by a clang that has a "/prebuilt/" somewhere along its path, so use the prebuilt version, but make sure to specify the target android api
 RUN set -x \
-    && curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
     && rm openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
-    && sed -i -e "s/mandroid/target\ armv7\-none\-linux\-androideabi/" Configure \
-    && CC=clang CXX=clang++ \
-           ./Configure android-armv7 \
-           no-asm \
-           no-shared --static \
+    && export PATH=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
+    && ./Configure android-arm \
+           -D__ANDROID_API__=21 \
+           -static \
+           no-shared no-tests \
            --with-zlib-include=${WORKDIR}/zlib/include --with-zlib-lib=${WORKDIR}/zlib/lib \
            --prefix=${PREFIX} --openssldir=${PREFIX} \
     && make -j${NPROC} \
-    && make install
+    && make install_sw
 
 # ZMQ
 ARG ZMQ_VERSION=v4.3.2
@@ -136,8 +135,30 @@ RUN set -x \
     && make  -j${NPROC} \
     && make install
 
+# libexpat (required by libunbound)
+ARG LIBEXPAT_VERSION=R_2_4_8
+ARG LIBEXPAT_HASH=3bab6c09bbe8bf42d84b81563ddbcf4cca4be838
+RUN set -x \
+    && git clone https://github.com/libexpat/libexpat.git -b ${LIBEXPAT_VERSION} \
+    && cd libexpat/expat \
+    && test `git rev-parse HEAD` = ${LIBEXPAT_HASH} || exit 1 \
+    && ./buildconf.sh \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=arm-linux-androideabi --enable-static --disable-shared \
+    && make  -j${NPROC} \
+    && make install
+
+# libunbound
+ARG LIBUNBOUND_VERSION=release-1.16.1
+ARG LIBUNBOUND_HASH=903538c76e1d8eb30d0814bb55c3ef1ea28164e8
+RUN git clone https://github.com/NLnetLabs/unbound.git -b ${LIBUNBOUND_VERSION}
+RUN set -x \
+    && cd unbound \
+    && test `git rev-parse HEAD` = ${LIBUNBOUND_HASH} || exit 1 \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=arm-linux-androideabi --enable-static --disable-shared --disable-flto --with-ssl=${PREFIX} --with-libexpat=${PREFIX} \
+    && make  -j${NPROC} \
+    && make install
+
 COPY . /src
-ARG NPROC=4
 RUN set -x \
     && cd /src \
     && CMAKE_INCLUDE_PATH="${PREFIX}/include" \

--- a/external-libs/android32.Dockerfile
+++ b/external-libs/android32.Dockerfile
@@ -82,8 +82,8 @@ RUN set -x \
 #Note : we build openssl because the default lacks DSA1
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.11
-ENV ZLIB_HASH c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+ENV ZLIB_VERSION 1.2.12
+ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
     && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android32_x86.Dockerfile
+++ b/external-libs/android32_x86.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/android
 ENV ANDROID_SDK_REVISION 4333796
 ENV ANDROID_SDK_HASH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
+    && curl -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && echo "${ANDROID_SDK_HASH}  sdk-tools-linux-${ANDROID_SDK_REVISION}.zip" | sha256sum -c \
     && unzip sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && rm -f sdk-tools-linux-${ANDROID_SDK_REVISION}.zip
@@ -16,7 +16,7 @@ RUN set -x \
 ENV ANDROID_NDK_REVISION 17c
 ENV ANDROID_NDK_HASH 3f541adbd0330a9205ba12697f6d04ec90752c53d6b622101a2a8a856e816589
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
+    && curl -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && echo "${ANDROID_NDK_HASH}  android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip" | sha256sum -c \
     && unzip android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && rm -f android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip
@@ -39,7 +39,7 @@ ARG CMAKE_VERSION=3.14.6
 ARG CMAKE_HASH=82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd
 RUN set -x \
     && cd /usr \
-    && curl -L -s -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
+    && curl -L -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && echo "${CMAKE_HASH}  cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c \
     && tar -xzf /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && rm -f /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
@@ -50,7 +50,7 @@ ARG BOOST_VERSION=1_70_0
 ARG BOOST_VERSION_DOT=1.70.0
 ARG BOOST_HASH=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 RUN set -x \
-    && curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+    && curl -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
     && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
     && tar -xvf boost_${BOOST_VERSION}.tar.bz2 \
     && rm -f boost_${BOOST_VERSION}.tar.bz2 \
@@ -60,18 +60,18 @@ RUN set -x \
 ENV HOST_PATH $PATH
 ENV PATH $TOOLCHAIN_DIR/i686-linux-android/bin:$TOOLCHAIN_DIR/bin:$PATH
 
-ARG NPROC=1
+ARG NPROC=4
 
 # Build iconv for lib boost locale
 ENV ICONV_VERSION 1.16
 ENV ICONV_HASH e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 RUN set -x \
-    && curl -s -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
+    && curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
     && echo "${ICONV_HASH}  libiconv-${ICONV_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf libiconv-${ICONV_VERSION}.tar.gz \
     && rm -f libiconv-${ICONV_VERSION}.tar.gz \
     && cd libiconv-${ICONV_VERSION} \
-    && CC=i686-linux-android-clang CXX=i686-linux-android-clang++ ./configure --build=x86_64-linux-gnu --host=i686-linux-android --prefix=${PREFIX} --disable-rpath \
+    && CC=clang CXX=clang++ ./configure --build=x86_64-linux-gnu --host=i686-linux-android --prefix=${PREFIX} --disable-rpath \
     && make -j${NPROC} && make install
 
 ## Build BOOST
@@ -79,13 +79,11 @@ RUN set -x \
     && cd boost_${BOOST_VERSION} \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
-#Note : we build openssl because the default lacks DSA1
-
 # download, configure and make Zlib
 ENV ZLIB_VERSION 1.2.12
 ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
-    && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
+    && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf zlib-${ZLIB_VERSION}.tar.gz \
     && rm zlib-${ZLIB_VERSION}.tar.gz \
@@ -94,23 +92,24 @@ RUN set -x \
     && make -j${NPROC}
 
 # open ssl
-ARG OPENSSL_VERSION=1.0.2p
-ARG OPENSSL_HASH=50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
+ARG OPENSSL_VERSION=3.0.5
+ARG OPENSSL_HASH=aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
+# openssl explicitly demands to be built by a clang that has a "/prebuilt/" somewhere along its path, so use the prebuilt version, but make sure to specify the target android api
 RUN set -x \
-    && curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
     && rm openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
-    && sed -i -e "s/mandroid/target\ i686\-linux\-android/" Configure \
-    && CC=clang CXX=clang++ \
-           ./Configure android \
-           no-asm \
-           no-shared --static \
+    && export PATH=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
+    && ./Configure android-x86 \
+           -D__ANDROID_API__=21 \
+           -static \
+           no-shared no-tests \
            --with-zlib-include=${WORKDIR}/zlib/include --with-zlib-lib=${WORKDIR}/zlib/lib \
            --prefix=${PREFIX} --openssldir=${PREFIX} \
     && make -j${NPROC} \
-    && make install
+    && make install_sw
 
 # ZMQ
 ARG ZMQ_VERSION=v4.3.2
@@ -136,8 +135,30 @@ RUN set -x \
     && make  -j${NPROC} \
     && make install
 
+# libexpat (required by libunbound)
+ARG LIBEXPAT_VERSION=R_2_4_8
+ARG LIBEXPAT_HASH=3bab6c09bbe8bf42d84b81563ddbcf4cca4be838
+RUN set -x \
+    && git clone https://github.com/libexpat/libexpat.git -b ${LIBEXPAT_VERSION} \
+    && cd libexpat/expat \
+    && test `git rev-parse HEAD` = ${LIBEXPAT_HASH} || exit 1 \
+    && ./buildconf.sh \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=x86-linux-android --enable-static --disable-shared \
+    && make  -j${NPROC} \
+    && make install
+
+# libunbound
+ARG LIBUNBOUND_VERSION=release-1.16.1
+ARG LIBUNBOUND_HASH=903538c76e1d8eb30d0814bb55c3ef1ea28164e8
+RUN git clone https://github.com/NLnetLabs/unbound.git -b ${LIBUNBOUND_VERSION}
+RUN set -x \
+    && cd unbound \
+    && test `git rev-parse HEAD` = ${LIBUNBOUND_HASH} || exit 1 \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=x86-linux-android --enable-static --disable-shared --disable-flto --with-ssl=${PREFIX} --with-libexpat=${PREFIX} \
+    && make  -j${NPROC} \
+    && make install
+
 COPY . /src
-ARG NPROC=4
 RUN set -x \
     && cd /src \
     && CMAKE_INCLUDE_PATH="${PREFIX}/include" \

--- a/external-libs/android32_x86.Dockerfile
+++ b/external-libs/android32_x86.Dockerfile
@@ -82,8 +82,8 @@ RUN set -x \
 #Note : we build openssl because the default lacks DSA1
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.11
-ENV ZLIB_HASH c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+ENV ZLIB_VERSION 1.2.12
+ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
     && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android64.Dockerfile
+++ b/external-libs/android64.Dockerfile
@@ -82,8 +82,8 @@ RUN set -x \
 #Note : we build openssl because the default lacks DSA1
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.11
-ENV ZLIB_HASH c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+ENV ZLIB_VERSION 1.2.12
+ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
     && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android64.Dockerfile
+++ b/external-libs/android64.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/android
 ENV ANDROID_SDK_REVISION 4333796
 ENV ANDROID_SDK_HASH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
+    && curl -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && echo "${ANDROID_SDK_HASH}  sdk-tools-linux-${ANDROID_SDK_REVISION}.zip" | sha256sum -c \
     && unzip sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && rm -f sdk-tools-linux-${ANDROID_SDK_REVISION}.zip
@@ -16,7 +16,7 @@ RUN set -x \
 ENV ANDROID_NDK_REVISION 17c
 ENV ANDROID_NDK_HASH 3f541adbd0330a9205ba12697f6d04ec90752c53d6b622101a2a8a856e816589
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
+    && curl -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && echo "${ANDROID_NDK_HASH}  android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip" | sha256sum -c \
     && unzip android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && rm -f android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip
@@ -39,7 +39,7 @@ ARG CMAKE_VERSION=3.14.6
 ARG CMAKE_HASH=82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd
 RUN set -x \
     && cd /usr \
-    && curl -L -s -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
+    && curl -L -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && echo "${CMAKE_HASH}  cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c \
     && tar -xzf /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && rm -f /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
@@ -50,7 +50,7 @@ ARG BOOST_VERSION=1_70_0
 ARG BOOST_VERSION_DOT=1.70.0
 ARG BOOST_HASH=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 RUN set -x \
-    && curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+    && curl -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
     && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
     && tar -xvf boost_${BOOST_VERSION}.tar.bz2 \
     && rm -f boost_${BOOST_VERSION}.tar.bz2 \
@@ -60,18 +60,18 @@ RUN set -x \
 ENV HOST_PATH $PATH
 ENV PATH $TOOLCHAIN_DIR/aarch64-linux-android/bin:$TOOLCHAIN_DIR/bin:$PATH
 
-ARG NPROC=1
+ARG NPROC=4
 
 # Build iconv for lib boost locale
 ENV ICONV_VERSION 1.16
 ENV ICONV_HASH e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 RUN set -x \
-    && curl -s -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
+    && curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
     && echo "${ICONV_HASH}  libiconv-${ICONV_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf libiconv-${ICONV_VERSION}.tar.gz \
     && rm -f libiconv-${ICONV_VERSION}.tar.gz \
     && cd libiconv-${ICONV_VERSION} \
-    && CC=aarch64-linux-android-clang CXX=aarch64-linux-android-clang++ ./configure --build=x86_64-linux-gnu --host=aarch64-linux-android --prefix=${PREFIX} --disable-rpath \
+    && CC=clang CXX=clang++ ./configure --build=x86_64-linux-gnu --host=aarch64-linux-android --prefix=${PREFIX} --disable-rpath \
     && make -j${NPROC} && make install
 
 ## Build BOOST
@@ -79,13 +79,11 @@ RUN set -x \
     && cd boost_${BOOST_VERSION} \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
-#Note : we build openssl because the default lacks DSA1
-
 # download, configure and make Zlib
 ENV ZLIB_VERSION 1.2.12
 ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
-    && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
+    && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf zlib-${ZLIB_VERSION}.tar.gz \
     && rm zlib-${ZLIB_VERSION}.tar.gz \
@@ -94,23 +92,24 @@ RUN set -x \
     && make -j${NPROC}
 
 # open ssl
-ARG OPENSSL_VERSION=1.0.2p
-ARG OPENSSL_HASH=50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
+ARG OPENSSL_VERSION=3.0.5
+ARG OPENSSL_HASH=aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
+# openssl explicitly demands to be built by a clang that has a "/prebuilt/" somewhere along its path, so use the prebuilt version, but make sure to specify the target android api
 RUN set -x \
-    && curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
     && rm openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
-    && sed -i -e "s/mandroid/target\ aarch64\-linux\-android/" Configure \
-    && CC=clang CXX=clang++ \
-           ./Configure android \
-           no-asm \
-           no-shared --static \
+    && export PATH=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
+    && ./Configure android-arm64 \
+           -D__ANDROID_API__=21 \
+           -static \
+           no-shared no-tests \
            --with-zlib-include=${WORKDIR}/zlib/include --with-zlib-lib=${WORKDIR}/zlib/lib \
            --prefix=${PREFIX} --openssldir=${PREFIX} \
     && make -j${NPROC} \
-    && make install
+    && make install_sw
 
 # ZMQ
 ARG ZMQ_VERSION=v4.3.2
@@ -136,8 +135,30 @@ RUN set -x \
     && make  -j${NPROC} \
     && make install
 
+# libexpat (required by libunbound)
+ARG LIBEXPAT_VERSION=R_2_4_8
+ARG LIBEXPAT_HASH=3bab6c09bbe8bf42d84b81563ddbcf4cca4be838
+RUN set -x \
+    && git clone https://github.com/libexpat/libexpat.git -b ${LIBEXPAT_VERSION} \
+    && cd libexpat/expat \
+    && test `git rev-parse HEAD` = ${LIBEXPAT_HASH} || exit 1 \
+    && ./buildconf.sh \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=aarch64-linux-android --enable-static --disable-shared \
+    && make  -j${NPROC} \
+    && make install
+
+# libunbound
+ARG LIBUNBOUND_VERSION=release-1.16.1
+ARG LIBUNBOUND_HASH=903538c76e1d8eb30d0814bb55c3ef1ea28164e8
+RUN git clone https://github.com/NLnetLabs/unbound.git -b ${LIBUNBOUND_VERSION}
+RUN set -x \
+    && cd unbound \
+    && test `git rev-parse HEAD` = ${LIBUNBOUND_HASH} || exit 1 \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=aarch64-linux-android --enable-static --disable-shared --disable-flto --with-ssl=${PREFIX} --with-libexpat=${PREFIX} \
+    && make  -j${NPROC} \
+    && make install
+
 COPY . /src
-ARG NPROC=4
 RUN set -x \
     && cd /src \
     && CMAKE_INCLUDE_PATH="${PREFIX}/include" \

--- a/external-libs/android64_x86.Dockerfile
+++ b/external-libs/android64_x86.Dockerfile
@@ -82,8 +82,8 @@ RUN set -x \
 #Note : we build openssl because the default lacks DSA1
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.11
-ENV ZLIB_HASH c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+ENV ZLIB_VERSION 1.2.12
+ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
     && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android64_x86.Dockerfile
+++ b/external-libs/android64_x86.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/android
 ENV ANDROID_SDK_REVISION 4333796
 ENV ANDROID_SDK_HASH 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
+    && curl -O https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && echo "${ANDROID_SDK_HASH}  sdk-tools-linux-${ANDROID_SDK_REVISION}.zip" | sha256sum -c \
     && unzip sdk-tools-linux-${ANDROID_SDK_REVISION}.zip \
     && rm -f sdk-tools-linux-${ANDROID_SDK_REVISION}.zip
@@ -16,7 +16,7 @@ RUN set -x \
 ENV ANDROID_NDK_REVISION 17c
 ENV ANDROID_NDK_HASH 3f541adbd0330a9205ba12697f6d04ec90752c53d6b622101a2a8a856e816589
 RUN set -x \
-    && curl -s -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
+    && curl -O https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && echo "${ANDROID_NDK_HASH}  android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip" | sha256sum -c \
     && unzip android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip \
     && rm -f android-ndk-r${ANDROID_NDK_REVISION}-linux-x86_64.zip
@@ -39,7 +39,7 @@ ARG CMAKE_VERSION=3.14.6
 ARG CMAKE_HASH=82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd
 RUN set -x \
     && cd /usr \
-    && curl -L -s -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
+    && curl -L -O https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && echo "${CMAKE_HASH}  cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum -c \
     && tar -xzf /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
     && rm -f /usr/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
@@ -50,7 +50,7 @@ ARG BOOST_VERSION=1_70_0
 ARG BOOST_VERSION_DOT=1.70.0
 ARG BOOST_HASH=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
 RUN set -x \
-    && curl -s -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
+    && curl -L -o  boost_${BOOST_VERSION}.tar.bz2 https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION}.tar.bz2 \
     && echo "${BOOST_HASH}  boost_${BOOST_VERSION}.tar.bz2" | sha256sum -c \
     && tar -xvf boost_${BOOST_VERSION}.tar.bz2 \
     && rm -f boost_${BOOST_VERSION}.tar.bz2 \
@@ -60,18 +60,18 @@ RUN set -x \
 ENV HOST_PATH $PATH
 ENV PATH $TOOLCHAIN_DIR/x86_64-linux-android/bin:$TOOLCHAIN_DIR/bin:$PATH
 
-ARG NPROC=1
+ARG NPROC=4
 
 # Build iconv for lib boost locale
 ENV ICONV_VERSION 1.16
 ENV ICONV_HASH e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 RUN set -x \
-    && curl -s -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
+    && curl -O http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${ICONV_VERSION}.tar.gz \
     && echo "${ICONV_HASH}  libiconv-${ICONV_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf libiconv-${ICONV_VERSION}.tar.gz \
     && rm -f libiconv-${ICONV_VERSION}.tar.gz \
     && cd libiconv-${ICONV_VERSION} \
-    && CC=x86_64-linux-android-clang CXX=x86_64-linux-android-clang++ ./configure --build=x86_64-linux-gnu --host=x86_64-linux-android --prefix=${PREFIX} --disable-rpath \
+    && CC=clang CXX=clang++ ./configure --build=x86_64-linux-gnu --host=x86_64-linux-android --prefix=${PREFIX} --disable-rpath \
     && make -j${NPROC} && make install
 
 ## Build BOOST
@@ -79,13 +79,11 @@ RUN set -x \
     && cd boost_${BOOST_VERSION} \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
-#Note : we build openssl because the default lacks DSA1
-
 # download, configure and make Zlib
 ENV ZLIB_VERSION 1.2.12
 ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 RUN set -x \
-    && curl -s -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
+    && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf zlib-${ZLIB_VERSION}.tar.gz \
     && rm zlib-${ZLIB_VERSION}.tar.gz \
@@ -94,23 +92,24 @@ RUN set -x \
     && make -j${NPROC}
 
 # open ssl
-ARG OPENSSL_VERSION=1.0.2p
-ARG OPENSSL_HASH=50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
+ARG OPENSSL_VERSION=3.0.5
+ARG OPENSSL_HASH=aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
+# openssl explicitly demands to be built by a clang that has a "/prebuilt/" somewhere along its path, so use the prebuilt version, but make sure to specify the target android api
 RUN set -x \
-    && curl -s -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && curl -O https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
     && echo "${OPENSSL_HASH}  openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c \
     && tar -xzf openssl-${OPENSSL_VERSION}.tar.gz \
     && rm openssl-${OPENSSL_VERSION}.tar.gz \
     && cd openssl-${OPENSSL_VERSION} \
-    && sed -i -e "s/mandroid/target\ x86_64\-linux\-android/" Configure \
-    && CC=clang CXX=clang++ \
-           ./Configure android \
-           no-asm \
-           no-shared --static \
+    && export PATH=${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
+    && ./Configure android-x86_64 \
+           -D__ANDROID_API__=21 \
+           -static \
+           no-shared no-tests \
            --with-zlib-include=${WORKDIR}/zlib/include --with-zlib-lib=${WORKDIR}/zlib/lib \
            --prefix=${PREFIX} --openssldir=${PREFIX} \
     && make -j${NPROC} \
-    && make install
+    && make install_sw
 
 # ZMQ
 ARG ZMQ_VERSION=v4.3.2
@@ -136,8 +135,30 @@ RUN set -x \
     && make  -j${NPROC} \
     && make install
 
+# libexpat (required by libunbound)
+ARG LIBEXPAT_VERSION=R_2_4_8
+ARG LIBEXPAT_HASH=3bab6c09bbe8bf42d84b81563ddbcf4cca4be838
+RUN set -x \
+    && git clone https://github.com/libexpat/libexpat.git -b ${LIBEXPAT_VERSION} \
+    && cd libexpat/expat \
+    && test `git rev-parse HEAD` = ${LIBEXPAT_HASH} || exit 1 \
+    && ./buildconf.sh \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=x86_64-linux-android --enable-static --disable-shared \
+    && make  -j${NPROC} \
+    && make install
+
+# libunbound
+ARG LIBUNBOUND_VERSION=release-1.16.1
+ARG LIBUNBOUND_HASH=903538c76e1d8eb30d0814bb55c3ef1ea28164e8
+RUN git clone https://github.com/NLnetLabs/unbound.git -b ${LIBUNBOUND_VERSION}
+RUN set -x \
+    && cd unbound \
+    && test `git rev-parse HEAD` = ${LIBUNBOUND_HASH} || exit 1 \
+    && CC=clang CXX=clang++ ./configure --prefix=${PREFIX} --host=x86_64-linux-android --enable-static --disable-shared --disable-flto --with-ssl=${PREFIX} --with-libexpat=${PREFIX} \
+    && make  -j${NPROC} \
+    && make install
+
 COPY . /src
-ARG NPROC=4
 RUN set -x \
     && cd /src \
     && CMAKE_INCLUDE_PATH="${PREFIX}/include" \

--- a/external-libs/include/wallet2_api.h
+++ b/external-libs/include/wallet2_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020, The Monero Project
+// Copyright (c) 2014-2022, The Monero Project
 // 
 // All rights reserved.
 // 
@@ -423,7 +423,6 @@ struct WalletListener
 
 /**
  * @brief Interface for wallet operations.
- *        TODO: check if /include/IWallet.h is still actual
  */
 struct Wallet
 {
@@ -928,6 +927,13 @@ struct Wallet
      */
     virtual bool importOutputs(const std::string &filename) = 0;
 
+    /*!
+     * \brief scanTransactions - scan a list of transaction ids, this operation may reveal the txids to the remote node and affect your privacy
+     * \param txids            - list of transaction ids
+     * \return                 - true on success
+     */
+    virtual bool scanTransactions(const std::vector<std::string> &txids) = 0;
+
     virtual TransactionHistory * history() = 0;
     virtual AddressBook * addressBook() = 0;
     virtual Subaddress * subaddress() = 0;
@@ -988,7 +994,7 @@ struct Wallet
      * \param message - the message to sign (arbitrary byte data)
      * \return the signature
      */
-    virtual std::string signMessage(const std::string &message) = 0;
+    virtual std::string signMessage(const std::string &message, const std::string &address = "") = 0;
     /*!
      * \brief verifySignedMessage - verify a signature matches a given message
      * \param message - the message (arbitrary byte data)
@@ -1029,6 +1035,7 @@ struct Wallet
     * \param offline - true/false
     */
     virtual void setOffline(bool offline) = 0;
+    virtual bool isOffline() const = 0;
     
     //! blackballs a set of outputs
     virtual bool blackballOutputs(const std::vector<std::string> &outputs, bool add) = 0;
@@ -1080,6 +1087,15 @@ struct Wallet
 
     //! shows address on device display
     virtual void deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId) = 0;
+
+    //! attempt to reconnect to hardware device
+    virtual bool reconnectDevice() = 0;
+
+    //! get bytes received
+    virtual uint64_t getBytesReceived() = 0;
+
+    //! get bytes sent
+    virtual uint64_t getBytesSent() = 0;
 };
 
 /**
@@ -1358,6 +1374,3 @@ struct WalletManagerFactory
 
 
 }
-
-namespace Bitmonero = Monero;
-


### PR DESCRIPTION
Fixes #855
You should use the v0.18 wallet with the monerujo patch, like [my fork](https://github.com/mstniy/monero/tree/release-v0.18-monerujo).