### PR TITLE
Fix Docker libs Builds [outdated zlib]

### DIFF
--- a/external-libs/android32.Dockerfile
+++ b/external-libs/android32.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable
 
-RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python libtool libtinfo5
+RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python3 python-is-python3 libtool libtinfo5
 
 WORKDIR /opt/android
 ## INSTALL ANDROID SDK
@@ -80,8 +80,8 @@ RUN set -x \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.12
-ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+ENV ZLIB_VERSION 1.3
+ENV ZLIB_HASH ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 RUN set -x \
     && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android32_x86.Dockerfile
+++ b/external-libs/android32_x86.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable
 
-RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python libtool libtinfo5
+RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python3 python-is-python3 libtool libtinfo5
 
 WORKDIR /opt/android
 ## INSTALL ANDROID SDK
@@ -80,8 +80,8 @@ RUN set -x \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.12
-ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+ENV ZLIB_VERSION 1.3
+ENV ZLIB_HASH ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 RUN set -x \
     && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android64.Dockerfile
+++ b/external-libs/android64.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable
 
-RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python libtool libtinfo5
+RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python3 python-is-python3 libtool libtinfo5
 
 WORKDIR /opt/android
 ## INSTALL ANDROID SDK
@@ -80,8 +80,8 @@ RUN set -x \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.12
-ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+ENV ZLIB_VERSION 1.3
+ENV ZLIB_HASH ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 RUN set -x \
     && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \

--- a/external-libs/android64_x86.Dockerfile
+++ b/external-libs/android64_x86.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable
 
-RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python libtool libtinfo5
+RUN set -x && apt-get update && apt-get install -y unzip automake build-essential curl file pkg-config git python3 python-is-python3 libtool libtinfo5
 
 WORKDIR /opt/android
 ## INSTALL ANDROID SDK
@@ -80,8 +80,8 @@ RUN set -x \
     && ./b2 --build-type=minimal link=static runtime-link=static --with-chrono --with-date_time --with-filesystem --with-program_options --with-regex --with-serialization --with-system --with-thread --with-locale --build-dir=android --stagedir=android toolset=clang threading=multi threadapi=pthread target-os=android -sICONV_PATH=${PREFIX} install -j${NPROC}
 
 # download, configure and make Zlib
-ENV ZLIB_VERSION 1.2.12
-ENV ZLIB_HASH 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+ENV ZLIB_VERSION 1.3
+ENV ZLIB_HASH ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 RUN set -x \
     && curl -O https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz \
     && echo "${ZLIB_HASH}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c \


### PR DESCRIPTION
Version 1.3 has these key updates from 1.2.13:

- Building using K&R (pre-ANSI) function definitions is no longer supported.
- Fixed a bug in deflateBound() for level 0 and memLevel 9.
- Fixed a bug when gzungetc() is used immediately after gzopen().
- Fixed a bug when using gzflush() with a very small buffer.
- Fixed a crash when gzsetparams() is attempted for a transparent write.
- Fixed test/example.c to work with FORCE_STORED.
- Fixed minizip to allow it to open an empty zip file.
- Fixed reading disk number start on zip64 files in minizip.
- Fixed a logic error in minizip argument processing.


note: merge #896 PR first as it's outdated