### PR TITLE
Background Sync via View-Key

### DIFF
--- a/app/src/main/cpp/monerujo.cpp
+++ b/app/src/main/cpp/monerujo.cpp
@@ -17,6 +17,7 @@
 #include <inttypes.h>
 #include "monerujo.h"
 #include "wallet2_api.h"
+#include <cassert>
 
 //TODO explicit casting jlong, jint, jboolean to avoid warnings
 

--- a/app/src/main/cpp/monerujo.cpp
+++ b/app/src/main/cpp/monerujo.cpp
@@ -297,6 +297,7 @@ JNIEXPORT jlong JNICALL
 Java_com_m2049r_xmrwallet_model_WalletManager_openWalletJ(JNIEnv *env, jobject instance,
                                                           jstring path, jstring password,
                                                           jint networkType) {
+	LOGD("openWalletJ(): start");
     const char *_path = env->GetStringUTFChars(path, nullptr);
     const char *_password = env->GetStringUTFChars(password, nullptr);
     Monero::NetworkType _networkType = static_cast<Monero::NetworkType>(networkType);
@@ -307,6 +308,13 @@ Java_com_m2049r_xmrwallet_model_WalletManager_openWalletJ(JNIEnv *env, jobject i
                     std::string(_password),
                     _networkType);
 
+	// setup background sync
+    bool setupStatus = wallet->setupBackgroundSync(Monero::Wallet::BackgroundSync_ReusePassword, std::string(_password), {});
+    if (setupStatus == true) {
+        LOGD("openWalletJ(): setupBackgroundSync(): success!");
+    } else {
+        LOGD("openWalletJ(): setupBackgroundSync(): failure!");
+    }
     env->ReleaseStringUTFChars(path, _path);
     env->ReleaseStringUTFChars(password, _password);
     return reinterpret_cast<jlong>(wallet);
@@ -938,6 +946,35 @@ JNIEXPORT void JNICALL
 Java_com_m2049r_xmrwallet_model_Wallet_pauseRefresh(JNIEnv *env, jobject instance) {
     Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
     wallet->pauseRefresh();
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_m2049r_xmrwallet_model_Wallet_startBackgroundSync(JNIEnv *env, jobject instance) {
+    LOGD("startBackgroundSync(): start");
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
+
+    bool bgsyncStatus = wallet->startBackgroundSync();
+    if (bgsyncStatus == true) {
+        LOGD("startBackgroundSync(): end: success!");
+    } else {
+        LOGD("startBackgroundSync(): end: fail!");
+    }
+    return static_cast<jboolean>(bgsyncStatus);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_m2049r_xmrwallet_model_Wallet_stopBackgroundSync(JNIEnv *env, jobject instance, jstring password) {
+    LOGD("stopBackgroundSync(): start");
+    Monero::Wallet *wallet = getHandle<Monero::Wallet>(env, instance);
+    const char *_password = env->GetStringUTFChars(password, nullptr);
+    bool bgsyncStatus = wallet->stopBackgroundSync(std::string(_password));
+    if (bgsyncStatus == true) {
+        LOGD("stopBackgroundSync(): end: success!");
+    } else {
+        LOGD("stopBackgroundSync(): end: fail!");
+    }
+    env->ReleaseStringUTFChars(password, _password);
+    return static_cast<jboolean>(bgsyncStatus);
 }
 
 JNIEXPORT jboolean JNICALL
@@ -1689,3 +1726,4 @@ int LedgerFind(char *buffer, size_t len) {
 #ifdef __cplusplus
 }
 #endif
+

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -103,6 +103,7 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
     private String uri = null;
 
     private long streetMode = 0;
+    private boolean isLockMode = false;
 
     @Override
     public void onPasswordChanged(String newPassword) {
@@ -310,9 +311,25 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
             } else {
                 onEnableStreetMode();
             }
+        } else if (itemId == R.id.action_lockmode) {
+            if (isStreetMode()) { // disable streetmode
+                isLockMode = false;
+                onDisableStreetMode();
+            } else {
+                onEnableLockMode();
+            }
         } else
             return super.onOptionsItemSelected(item);
         return true;
+    }
+
+    @Override
+    public boolean isLockMode() { return isLockMode; }
+
+    private void onEnableLockMode() {
+        isLockMode = true;
+        enableStreetMode(true);
+        updateStreetMode();
     }
 
     private void updateStreetMode() {

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -35,6 +35,7 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.Switch;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -104,6 +105,8 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
 
     private long streetMode = 0;
     private boolean isLockMode = false;
+    private SharedPreferences sharedPreferences ;
+    private boolean enableBkgSync;
 
     @Override
     public void onPasswordChanged(String newPassword) {
@@ -318,9 +321,37 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
             } else {
                 onEnableLockMode();
             }
+        } else if (itemId == R.id.action_background_sync) {
+            showToggleDialog();
         } else
             return super.onOptionsItemSelected(item);
         return true;
+    }
+
+    private void showToggleDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("Background Sync");
+
+        // set the custom layout
+        final View customLayout = getLayoutInflater().inflate(R.layout.toggle_dialog_layout, null);
+        builder.setView(customLayout);
+
+        // Access the Switch widget and TextView from the inflated layout
+        final Switch toggleSwitch = customLayout.findViewById(R.id.toggleSwitch);
+
+        // Initialize the toggle button state
+        toggleSwitch.setChecked(enableBkgSync);
+
+        builder.setPositiveButton("OK", (dialogInterface, which) -> {
+            // Save the toggle state to SharedPreferences
+            enableBkgSync = toggleSwitch.isChecked();
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putBoolean("toggleState", enableBkgSync);
+            editor.apply();
+        });
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
     }
 
     @Override
@@ -330,6 +361,10 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
         isLockMode = true;
         enableStreetMode(true);
         updateStreetMode();
+
+        if(getWallet() != null && enableBkgSync) {
+            getWallet().startBackgroundSync();
+        }
     }
 
     private void updateStreetMode() {
@@ -348,6 +383,10 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
                 runOnUiThread(() -> {
                     enableStreetMode(false);
                     updateStreetMode();
+
+                    if(getWallet() != null) {
+                        getWallet().stopBackgroundSync(password);
+                    }
                 });
             }
 
@@ -431,6 +470,9 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
 
         startWalletService();
         Timber.d("onCreate() done.");
+
+        sharedPreferences = getSharedPreferences("MyPrefs", Context.MODE_PRIVATE);
+        enableBkgSync = sharedPreferences.getBoolean("toggleState", false);
     }
 
     public void showNet() {

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletFragment.java
@@ -219,12 +219,21 @@ public class WalletFragment extends Fragment
         String balance = amountToString(amountA);
         tvBalance.setText(balance);
         final boolean streetMode = activityCallback.isStreetMode();
-        if (!streetMode) {
-            llBalance.setVisibility(View.VISIBLE);
+        final boolean lockMode = activityCallback.isLockMode();
+        if (lockMode) {
+            llBalance.setVisibility(View.INVISIBLE);
             tvStreetView.setVisibility(View.INVISIBLE);
-        } else {
+            txlist.setVisibility(View.INVISIBLE);
+        } else if (streetMode) {
             llBalance.setVisibility(View.INVISIBLE);
             tvStreetView.setVisibility(View.VISIBLE);
+            if(txlist != null)
+                txlist.setVisibility(View.VISIBLE);
+        } else {
+            llBalance.setVisibility(View.VISIBLE);
+            tvStreetView.setVisibility(View.INVISIBLE);
+            if(txlist != null)
+                txlist.setVisibility(View.VISIBLE);
         }
         setStreetModeBackground(streetMode);
     }
@@ -492,6 +501,8 @@ public class WalletFragment extends Fragment
         boolean isSynced();
 
         boolean isStreetMode();
+
+        boolean isLockMode();
 
         long getStreetModeHeight();
 

--- a/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/model/Wallet.java
@@ -297,6 +297,10 @@ public class Wallet {
 
     public native void pauseRefresh();
 
+    public native boolean startBackgroundSync();
+
+    public native boolean stopBackgroundSync(String password);
+
     public native boolean refresh();
 
     public native void refreshAsync();
@@ -521,3 +525,4 @@ public class Wallet {
         }
     }
 }
+

--- a/app/src/main/res/layout/toggle_dialog_layout.xml
+++ b/app/src/main/res/layout/toggle_dialog_layout.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="30dp">
+
+    <!-- Text at the top -->
+    <TextView
+        android:id="@+id/topTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Background Sync enables users to keep their wallets syncing in the background using only their view-keys, and having their spend key wiped from memory."
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    <!-- Layout for the text and switch -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="8dp"
+        android:paddingStart="20dp">
+
+        <!-- Text on the left -->
+        <TextView
+            android:id="@+id/leftTextView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Enable Background Sync"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <!-- Switch on the right -->
+        <Switch
+            android:id="@+id/toggleSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end" />
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/wallet_menu.xml
+++ b/app/src/main/res/menu/wallet_menu.xml
@@ -54,4 +54,9 @@
         android:title="@string/pocketchange_title"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_background_sync"
+        android:orderInCategory="900"
+        android:title="@string/background_sync"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/wallet_menu.xml
+++ b/app/src/main/res/menu/wallet_menu.xml
@@ -3,6 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_lockmode"
+        android:checkable="true"
+        android:icon="@drawable/ic_lock_24dp"
+        android:orderInCategory="90"
+        android:title="@string/menu_lockmode"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/action_streetmode"
         android:checkable="true"
         android:icon="@drawable/gunther_24dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,4 +499,5 @@
 
     <string name="label_apply">APPLY</string>
     <string name="menu_lockmode">Lock Mode</string>
+    <string name="background_sync">Background Sync</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,4 +498,5 @@
     <string name="pocketchange_create_title">Create Change</string>
 
     <string name="label_apply">APPLY</string>
+    <string name="menu_lockmode">Lock Mode</string>
 </resources>


### PR DESCRIPTION
This PR designed to [implement background wallet sync via view keys on Monerujo. ](https://bounties.monero.social/posts/10/5-100m-implement-background-wallet-sync-via-view-keys-on-monerujo)

To enable background syncing, tap the 3-dot menu, select Background Sync, and tap the Enable Background Sync toggle.

In order to demonstrate the feature most effectively, I created a simple lockscreen triggered by the new lock icon in the top right of the main screen. I have purposefully left the UX as simple as possible so that the Monerjo team can package it as they see fit.

With background sync enabled, the lock icon acts as the trigger: locking the wallet enables background sync, and unlocking disables it.

I also have left the Receive/Give buttons intact on the lockscreen to demonstrate that once background sync is enabled, the wallet's spend key is wiped from memory, which will lead to failure when trying to construct a transaction. These buttons can easily be removed in the final UX if Monerujo team decides to keep the lockscreen in place.

Street Mode is unaffected when background sync is enabled.

My personal feedback:

1) The on/off toggle and menu option seems unnecessary, as view-key syncing should just be the default/only way to sync.
	
2) I've left out "Sync only over WiFi" option mentioned in the bounty, as its already an option available in Android Settings (Monerujo > App Info > Mobile data & Wi-Fi > Background data). Monerujo _already_ syncs in the background regardless of what connection is used, and since this PR doesn't affect the amount of data being synced, I kept the default behaviour. If Monerujo devs want to add an in-app WiFi only option, it should be a global setting, not specific to this feature.
	
3) Monerujo should add a prompt to set the app to "Unoptimized" in battery settings, to avoid Android killing the app while its in the background.
	
Donations: `866SAS9afc7GMQAQLz5KbyCBqP38K1MUb4jeGCwCnqALFz4pcXKGfYFAaP8txom4JjPxzEUsinVQERd7tsRTgNKXSovyQrg`

APK Download: https://we.tl/t-6eE0UCbsQZ

APK SHA256: 7783ae19ac2993d292c18758d3b6d9e58096245fde917646332d2c306ae18257  

Time lapse video of the feature:

https://github.com/m2049r/xmrwallet/assets/163790330/c2b5dcdd-a362-4808-8659-ee804de62f38

