### PR TITLE
Add monochrome launcher icon

### DIFF
--- a/app/src/main/res/drawable-v24/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_monochrome.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group android:scaleX="0.9961111"
+      android:scaleY="0.9961111"
+      android:translateX="0.21"
+      android:translateY="0.21">
+    <path
+        android:pathData="M62.76,39.37a11.13,11.13 0,0 0,-8.86 4.39,11.13 11.13,0 0,0 -15.42,-2.25V40H33.89V67.87h4.59V50.53a6.57,6.57 0,1 1,13.13 0V67.87H56.2V50.53a6.57,6.57 0,1 1,13.13 0V67.87a6.57,6.57 0,0 1,-6.57 6.56V79A11.17,11.17 0,0 0,73.92 67.87V49.28h0A11.24,11.24 0,0 0,62.76 39.37Z"
+        android:fillColor="#fff"/>
+    <path
+        android:pathData="M71.62,33.07m-2.38,0a2.38,2.38 0,1 1,4.76 0a2.38,2.38 0,1 1,-4.76 0"
+        android:fillColor="#fff"/>
+  </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Adding a monochrome aka [adaptive](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive) launcher icon. Users can enable this new **optional** feature since Android 13, and a lot of third party apps (including commercial) already support it, e.g. [Cryptomator](https://github.com/cryptomator/android/blob/develop/presentation/src/main/res/mipmap-anydpi-v26/ic_launcher.xml), Firefox, Slack, Proton Mail, Google Maps, etc.

I've created this new `ic_launcher_monochrome.xml` by simply copying the [ic_launcher_foreground.xml](https://github.com/m2049r/xmrwallet/blob/master/app/src/main/res/drawable-v24/ic_launcher_foreground.xml) and removing the background gradient elements.

Tested on the Pixel emulators with Android 10 (no effect), 14, and 15, and Samsung with Android 14.

Before, after:

![Screenshot_20241019_163516](https://github.com/user-attachments/assets/3d1a20cc-686d-4c95-9016-20f1583ef38b) ![Screenshot_20241019_163538](https://github.com/user-attachments/assets/226d514a-601e-49ac-b372-63d91449b52d)

Fixes #947, #866