### PR TITLE
Remove a few fuzzy translations

### DIFF
--- a/app/src/main/res/values-cat/strings.xml
+++ b/app/src/main/res/values-cat/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Premi aquí per mostrar codi QR</string>
 
-    <string name="info_xmrto_enabled">Pagament amb BTC habilitat, premi aquí per més informació.</string>
     <string name="info_ledger_enabled">Ledger habilitat, premi aquí per més informació.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Canvi: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Visita %1$s per suport i seguiment</string>
-    <string name="label_send_btc_xmrto_key_lb">Clau secreta\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Clau secreta %1$s</string>
     <string name="label_send_btc_address">Adreça %1$s de destí</string>
     <string name="label_send_btc_amount">Quantitat</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Canvi de contrasenya fallit!</string>
     <string name="changepw_success">La contrasenya ha canviat</string>
 
-    <string name="label_daemon">Node</string>
     <string name="status_wallet_loading">Carregant Portamonedes &#8230;</string>
     <string name="status_wallet_unloaded">Portamonedes desat</string>
     <string name="status_wallet_unload_failed">Ha fallat el desat del portamonedas!</string>
@@ -136,11 +131,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s sense confirmar</string>
 
-    <string name="service_description">Servei de monerujo</string>
 
     <string name="status_synced">Sincronitzat:</string>
     <string name="status_remaining">Blocs restants</string>
-    <string name="status_syncing">Escanejant:</string>
 
     <string name="message_camera_not_permitted">Sense càmara = Cap escaneig QR!</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -31,7 +31,6 @@
 
     <string name="label_receive_info_gen_qr_code">Berühren für QR-Code</string>
 
-    <string name="info_xmrto_enabled">BTC-Zahlung aktiviert – Tippe für mehr Infos.</string>
     <string name="info_ledger_enabled">Ledger aktiviert – Tippe für mehr Infos.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Kurs: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Besuche %1$s für Support &amp; Nachverfolgung</string>
-    <string name="label_send_btc_xmrto_key_lb">Geheimer Schlüssel\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Geheimer Schlüssel</string>
     <string name="label_send_btc_address">%1$s-Zieladresse</string>
     <string name="label_send_btc_amount">Betrag</string>
 
@@ -99,7 +95,6 @@
     <string name="changepw_failed">Passwort ändern fehlgeschlagen!</string>
     <string name="changepw_success">Passwort geändert</string>
 
-    <string name="label_daemon">Node</string>
     <string name="status_wallet_loading">Lade Wallet &#8230;</string>
     <string name="status_wallet_unloaded">Wallet gespeichert</string>
     <string name="status_wallet_unload_failed">Speichern des Wallets fehlgeschlagen!</string>
@@ -137,11 +132,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s unbestätigt</string>
 
-    <string name="service_description">monerujo Service</string>
 
     <string name="status_synced">Synchronisiert:</string>
     <string name="status_remaining">Blöcke verbleibend</string>
-    <string name="status_syncing">Scanne:</string>
 
     <string name="message_camera_not_permitted">Benötigt Kamerazugriff zum scannen von QR-Codes!</string>
 
@@ -363,7 +356,6 @@
     <string name="onboarding_seed_title">Halte deinen Seed geheim</string>
     <string name="onboarding_seed_information">Der Seed ermöglicht vollen Zugriff auf deine Monero - jedem der ihn besitzt. Du bist in der Verantwortung: Wenn du ihn verlierst, kann ihn niemand wiederherstellen und deine gespeicherten Monero sind verloren.</string>
     <string name="onboarding_xmrto_title">Sende Krypto</string>
-    <string name="onboarding_xmrto_information">Monerujo hat exchange unterstützung eingebaut. Scanne oder kopiere einfach eine BTC, LTC, ETH, TRXUSDT oder SOL Adresse und schon kannst du mit deinen XMR bezahlen.</string>
     <string name="onboarding_nodes_title">Nodes und deine Knoten</string>
     <string name="onboarding_nodes_information">Nodes(Knoten) verbinden dich mit dem Moneronetzwerk. Du kannst öffentliche Nodes oder deinen eigenen verwenden.</string>
     <string name="onboarding_fpsend_title">Sende Geld mit deinem Fingerabdruck</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -29,7 +29,6 @@
 
     <string name="label_receive_info_gen_qr_code">Πατήστε για QR κωδικό</string>
 
-    <string name="info_xmrto_enabled">Συναλλαγή BTC ενεργοποιήθηκε, πάτα για περισσότερες πληροφορείες.</string>
     <string name="info_ledger_enabled">Ledger ενεργοποιήθηκε, πάτα για περισσότερες πληροφορείες.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -73,9 +72,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rate: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Επίσκεψη στο %1$s για υποστήριξη &amp; με εντοπισμό συναλλαγής</string>
-    <string name="label_send_btc_xmrto_key_lb">Μυστικό Κλειδί\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Μυστικό Κλειδί</string>
     <string name="label_send_btc_address">%1$s Διεύθυνση Παραλήπτη</string>
     <string name="label_send_btc_amount">Ποσό</string>
 
@@ -93,7 +89,6 @@
     <string name="backup_failed">Η δημιουργία αντίγραφου ασφαλείας απέτυχε!</string>
     <string name="rename_failed">Η μετονομασία απέτυχε!</string>
 
-    <string name="label_daemon">Κόμβος(Δαίμονας)</string>
     <string name="status_wallet_loading">Φόρτωση Πορτοφολιού &#8230;</string>
     <string name="status_wallet_unloaded">Πορτοφόλι αποθηκεύτηκε</string>
     <string name="status_wallet_unload_failed">Η αποθήκευση του πορτοφολιού απέτυχε!</string>
@@ -125,11 +120,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s μη επιβεβαιωμένα</string>
 
-    <string name="service_description">Υπηρεσία monerujo</string>
 
     <string name="status_synced">Συγχρονισμένα:</string>
     <string name="status_remaining">Μπλοκς που απομένουν</string>
-    <string name="status_syncing">Έρευνα:</string>
 
     <string name="message_camera_not_permitted">Όχι κάμερα = Όχι QR σκανάρισμα!</string>
 

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Tuŝu por QR-kodo</string>
 
-    <string name="info_xmrto_enabled">BTC-pago permesita, frapetu por detaloj.</string>
     <string name="info_ledger_enabled">Ledger permesita, frapetu por detaloj.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(kurzo: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Vizitu %1$s por helpo kaj sekvado</string>
-    <string name="label_send_btc_xmrto_key_lb">Sekreta ŝlosilo\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s sekreta ŝlosilo</string>
     <string name="label_send_btc_address">Ricevanta %1$s-adreso</string>
     <string name="label_send_btc_amount">Kvanto</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Pasvortŝanĝo malsukcesis!</string>
     <string name="changepw_success">Pasvortŝanĝo sukcesis!</string>
 
-    <string name="label_daemon">Nodo</string>
     <string name="status_wallet_loading">Ŝarĝante la monujon &#8230;</string>
     <string name="status_wallet_unloaded">La monujo konserviĝis</string>
     <string name="status_wallet_unload_failed">La monujkonservoo malsukcesis!</string>
@@ -136,11 +131,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s nekonfirmite</string>
 
-    <string name="service_description">monerujo Servo</string>
 
     <string name="status_synced">Sinkronizas:</string>
     <string name="status_remaining">Restaj blokoj</string>
-    <string name="status_syncing">Skanante:</string>
 
     <string name="message_camera_not_permitted">Neniu filmilo = Neniu QR-kodo skaniĝas!</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,7 +55,6 @@
     <string name="changepw_failed">¡Cambio de contraseña fallido!</string>
     <string name="changepw_success">Contraseña cambiada</string>
 
-    <string name="label_daemon">Nodo</string>
     <string name="status_wallet_loading">Cargando monedero&#8230;</string>
     <string name="status_wallet_unloaded">Monedero guardado</string>
     <string name="status_wallet_unload_failed">¡Fallo al guardar el monedero!</string>
@@ -81,7 +80,6 @@
     <string name="bad_password">¡Contraseña incorrecta!</string>
     <string name="bad_saved_password">La contraseña guardada es incorrecta.\nIngrésala manualmente.</string>
     <string name="bad_wallet">¡El monedero no existe!</string>
-    <string name="prompt_daemon_missing">¡La dirección del daemon debe estar configurada!</string>
     <string name="prompt_wrong_net">El monedero no coincide con la red seleccionada</string>
 
     <string name="label_watchonly">(Sólo Vista)</string>
@@ -91,7 +89,6 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s sin confirmar</string>
 
-    <string name="service_description">Monedero abierto</string>
 
     <string name="status_synced">Sincronizado:</string>
     <string name="status_remaining">bloques restantes</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Puuduta QR koodi saamiseks</string>
 
-    <string name="info_xmrto_enabled">Bitcoini maksed sisse lülitatud, puuduta lisainfo saamiseks.</string>
     <string name="info_ledger_enabled">Ledger\'i tugi sisse lülitatud, puuduta lisainfo saamiseks.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Kurss: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Külasta %1$s lisainfo saamiseks &amp; jälgin</string>
-    <string name="label_send_btc_xmrto_key_lb">Privaatvõti\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s privaatvõti</string>
     <string name="label_send_btc_address">Sihtkoha %1$s aadress</string>
     <string name="label_send_btc_amount">Kogus</string>
 
@@ -96,7 +92,6 @@
     <string name="changepw_failed">Parooli vahetamine ebaõnnestus!</string>
     <string name="changepw_success">Parool vahetatud</string>
 
-    <string name="label_daemon">Server</string>
     <string name="status_wallet_loading">Laen rahakotti &#8230;</string>
     <string name="status_wallet_unloaded">Rahakott salvestatud</string>
     <string name="status_wallet_unload_failed">Rahakoti salvestamine ebaõnnestus!</string>
@@ -134,11 +129,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s kinnitamata</string>
 
-    <string name="service_description">monerujo teenus</string>
 
     <string name="status_synced">Uuendatud:</string>
     <string name="status_remaining">Plokki veel</string>
-    <string name="status_syncing">Uuendamine:</string>
 
     <string name="message_camera_not_permitted">Pole kaamerat = pole QR koodide lugemist!</string>
 
@@ -229,7 +222,6 @@
 
     <string name="send_create_tx_error_title">Viga ülekande genereerimisel</string>
 
-    <string name="tx_list_fee">teenustasu %1$s</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">ebaõnnestus</string>
     <string name="tx_list_amount_negative">- %1$s</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -31,7 +31,6 @@
 
     <string name="label_receive_info_gen_qr_code">برای نمایش کد کیوآر لمس کنید</string>
 
-    <string name="info_xmrto_enabled">پرداخت‌های غیر مونرویی فعال شد، برای اطلاعات بیشتر لمس کنید.</string>
     <string name="info_ledger_enabled">پشتیبانی از لجر فعال شد، برای اطلاعات بیشتر لمس کنید.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -127,17 +126,6 @@
     (نرخ:
     %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">
-    برای پشتیبانی و رهگیری سفارش به
-    %1$s
-    مراجعه کنید
-    </string>
-    <string name="label_send_btc_xmrto_key_lb">
-    کلید خصوصی
-    \n%1$s</string>
-    <string name="label_send_btc_xmrto_key">
-    کلید خصوصی %s
-    </string>
     <string name="label_send_btc_address">
     آدرس مقصد
     %1$s
@@ -166,7 +154,6 @@
     <string name="changepw_failed">تغییر رمز شکست خورد!</string>
     <string name="changepw_success">رمز عبور تغییر کرد</string>
 
-    <string name="label_daemon">شبکه</string>
     <string name="status_wallet_loading">بارگذاری کیف پول...</string>
     <string name="status_wallet_unloaded">کیف پول ذخیره شد</string>
     <string name="status_wallet_unload_failed">ذخیرهٔ کیف پول شکست خورد!</string>
@@ -241,11 +228,9 @@
     تایید نشده است
     </string>
 
-    <string name="service_description">سرویس مونروجو</string>
 
     <string name="status_synced">همگام شد:</string>
     <string name="status_remaining">بلوک باقی مانده</string>
-    <string name="status_syncing">در حال اسکن:</string>
 
     <string name="message_camera_not_permitted">بدون دوربین نمی‌توان کدها را اسکن کرد!</string>
 
@@ -375,9 +360,6 @@
 
     <string name="send_create_tx_error_title">ساخت خطای تراکنش</string>
 
-    <string name="tx_list_fee">
-    هزینهٔ تراکنش
-    %1$s</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">شکست خورد</string>
     <string name="tx_list_amount_negative">-%1$s</string>
@@ -557,9 +539,7 @@
     این بذر به هرکسی که آن را در اختیار دارد دسترسی کامل می‌دهد. اگر آن را از دست بدهید، ما نمی‌توانیم به شما کمک کنیم آن را بازیابی کنید و مونروهای محبوب خود را از دست می دهید.
     </string>
     <string name="onboarding_xmrto_title">هرنوع رمزارز ارسال کنید</string>
-    <string name="onboarding_xmrto_information">
-    Monerujo دارای پشتیبانی صرافی داخلی است. فقط یک آدرس BTC، LTC، ETH، TRXUSDT یا SOL را بچسبانید یا اسکن کنید و با خرج کردن XMR، این رمزارزها را ارسال خواهید کرد (آدرس IP ایران در تحریم است).
-    </string>
+
     <string name="onboarding_nodes_title">گره‌ها، به میل شما</string>
     <string name="onboarding_nodes_information">
     گره‌ها شما را به شبکه مونرو متصل می‌کنند. از بین گره‌های عمومی یکی را انتخاب کنید یا با استفاده از گرهٔ خود متصل شوید.

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -34,7 +34,6 @@
 
     <string name="label_receive_info_gen_qr_code">Toucher pour le QR Code</string>
 
-    <string name="info_xmrto_enabled">Paiement BTC activé, tapez pour plus d\'infos.</string>
     <string name="info_ledger_enabled">Ledger activé, tapez pour plus d\'infos.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -78,9 +77,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Taux : %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Visitez %1$s pour l\'assistance &amp; le suivi</string>
-    <string name="label_send_btc_xmrto_key_lb">Clef Secrète\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Clef Secrète %1$s</string>
     <string name="label_send_btc_address">Adresse %1$s Destination</string>
     <string name="label_send_btc_amount">Montant</string>
 
@@ -131,7 +127,6 @@
     <string name="bad_password">Mot de passe incorrect !</string>
     <string name="bad_saved_password">Mot de passe sauvegardé incorrect.\nVeuillez entrer le mot de passe manuellement.</string>
     <string name="bad_wallet">Portefeuille inexistant !</string>
-    <string name="prompt_daemon_missing">L\'adresse du démon ne peut pas être configurée !</string>
     <string name="prompt_wrong_net">Portefeuille incompatible avec le réseau sélectionné</string>
 
     <string name="label_watchonly">(Audit)</string>
@@ -141,11 +136,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s non confirmés</string>
 
-    <string name="service_description">Service monerujo</string>
 
     <string name="status_synced">Synchronisé :</string>
     <string name="status_remaining">Blocs restant</string>
-    <string name="status_syncing">Analyse :</string>
 
     <string name="message_camera_not_permitted">Pas de caméra = Pas de Scan QR !</string>
 
@@ -368,7 +361,6 @@
     <string name="onboarding_seed_title">Gardez votre phrase mnémonique en sécurité</string>
     <string name="onboarding_seed_information">La phrase mnémonique donne un accès complet à celui qui le détient. Si vous le perdez, nous ne pouvons pas vous aider à la restaurer et vous perdrez vos précieux moneroj.</string>
     <string name="onboarding_xmrto_title">Envoyer des cryptomonnaies</string>
-    <string name="onboarding_xmrto_information">Monerujo prend en charge SideShift.ai. Collez simplement ou analysez une adresse BTC, LTC, ETH, DASH ou DOGE et vous enverrez ces cryptomonnaies en envoyant dépensant des XMR.</string>
     <string name="onboarding_nodes_title">Les nœuds, à votre façon</string>
     <string name="onboarding_nodes_information">Les nœuds assurent votre connexion au réseau Monero. Choisissez parmi des nœuds publics ou devenez un cypherpunk complet en utilisant le vôtre.</string>
     <string name="onboarding_fpsend_title">Envoyer avec l\'empreinte digitale</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -31,7 +31,6 @@
 
     <string name="label_receive_info_gen_qr_code">לחץ עבור קוד QR</string>
 
-    <string name="info_xmrto_enabled">תשלומים שאינם XMR מופעלים, הקש לקבלת מידע נוסף.</string>
     <string name="info_ledger_enabled">Ledger מופעל, הקש לקבלת מידע נוסף.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(שיעור: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">בקר ב-%1$s לקבלת תמיכה  &amp; מעקב</string>
-    <string name="label_send_btc_xmrto_key_lb">מפתח סודי\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s מפתח סודי</string>
     <string name="label_send_btc_address">כתובת %1$s היעד</string>
     <string name="label_send_btc_amount">כמות</string>
 
@@ -142,7 +138,6 @@
 
     <string name="status_synced">מסונכרן:</string>
     <string name="status_remaining">בלוקים שנותרו</string>
-    <string name="status_syncing">מחפש:</string>
 
     <string name="message_camera_not_permitted">אין מצלמה = אין סריקת QR!</string>
 
@@ -362,7 +357,6 @@
     <string name="onboarding_seed_title">שמור על הסיד שלך בטוח</string>
     <string name="onboarding_seed_information">הסיד מעניק גישה מלאה למי שיש אותו. אם אתה מאבד את זה, אנחנו לא יכולים לעזור לך לשחזר את זה ואתה מאבד את המונרוג\' האהוב שלך.</string>
     <string name="onboarding_xmrto_title">שלח קריפטו</string>
-    <string name="onboarding_xmrto_information">למונרוג\'ו יש את התמיכה של exchange מובנת. פשוט הדבק או סרוק BTC, LTC, ETH, TRXUSDT או SOL כתובת ואתה תשלח את הקריפטו האלה על ידי הוצאת XMR.</string>
     <string name="onboarding_nodes_title">החוליות, בדרך שלך</string>
     <string name="onboarding_nodes_information">החוליות מחברות אותך לרשת מונרו. בחר בין החוליות הציבוריות או שתתחבר לאחת משלך.</string>
     <string name="onboarding_fpsend_title">שלח עם טביעת אצבע</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Koppints a QR-kódért</string>
 
-    <string name="info_xmrto_enabled">BTC fizetés engedélyezve, koppints ide a részletekért.</string>
     <string name="info_ledger_enabled">Ledger engedélyezve, koppints ide a részletekért</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Arány: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Segítségért és nyomonkövetésért látogass el az %1$s weboldalra</string>
-    <string name="label_send_btc_xmrto_key_lb">Titkos kulcs\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s titkos kulcs</string>
     <string name="label_send_btc_address">Kedvezményezett %1$s-címe</string>
     <string name="label_send_btc_amount">Mennyiség</string>
 
@@ -96,7 +92,6 @@
     <string name="changepw_failed">Sikertelen jelszómódosítás!</string>
     <string name="changepw_success">Jelszó megváltoztatva</string>
 
-    <string name="label_daemon">Csomópont</string>
     <string name="status_wallet_loading">Tárca betöltése&#8230;</string>
     <string name="status_wallet_unloaded">Tárca mentve</string>
     <string name="status_wallet_unload_failed">Sikertelen mentés!</string>
@@ -124,7 +119,6 @@
     <string name="bad_password">Helytelen jelszó!</string>
     <string name="bad_saved_password">Az elmentett jelszó helytelen.\nKérlek, add meg a jelszót manuálisan.</string>
     <string name="bad_wallet">A tárca nem létezik!</string>
-    <string name="prompt_daemon_missing">A daemon címét meg kell adni!</string>
     <string name="prompt_wrong_net">A tárcához nem a megfelelő hálózat van kiválasztva</string>
 
     <string name="label_watchonly">(csak megtekintés)</string>
@@ -134,11 +128,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s függőben</string>
 
-    <string name="service_description">monerujo szolgáltatás</string>
 
     <string name="status_synced">Szinkronizálva:</string>
     <string name="status_remaining">blokk van hátra</string>
-    <string name="status_syncing">Beolvasás:</string>
 
     <string name="message_camera_not_permitted">Ha nincs kamera, nincs QR-kód beolvasás sem!</string>
 
@@ -228,7 +220,6 @@
 
     <string name="send_create_tx_error_title">Tranzakciólétrehozási hiba</string>
 
-    <string name="tx_list_fee">%1$s díj</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">sikertelen</string>
     <string name="tx_list_amount_negative">- %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Tocca per il codice QR</string>
 
-    <string name="info_xmrto_enabled">Pagamento BTC abilitato, tocca per maggiori informazioni.</string>
     <string name="info_ledger_enabled">Ledger abilitato, tocca per maggiori informazioni.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Tasso: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Visita %1$s per supporto e tracciamento</string>
-    <string name="label_send_btc_xmrto_key_lb">Chiave segreta\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Chiave segreta %1$s</string>
     <string name="label_send_btc_address">Indirizzo %1$s di destinazione</string>
     <string name="label_send_btc_amount">Ammontare</string>
 
@@ -98,7 +94,6 @@
     <string name="changepw_failed">Modifica password fallita!</string>
     <string name="changepw_success">Password cambiata</string>
 
-    <string name="label_daemon">Nodo</string>
     <string name="status_wallet_loading">Caricando portafoglio &#8230;</string>
     <string name="status_wallet_unloaded">Portafoglio salvato</string>
     <string name="status_wallet_unload_failed">Salvataggio portafoglio fallito!</string>
@@ -126,7 +121,6 @@
     <string name="bad_password">Password errata!</string>
     <string name="bad_saved_password">La password salvata è scorretta.\nInserisci la password manualmente.</string>
     <string name="bad_wallet">Il portafoglio non esiste!</string>
-    <string name="prompt_daemon_missing">Deve essere impostato l\'indirizzo del Daemon!</string>
     <string name="prompt_wrong_net">Il portafoglio non si abbina con la rete selezionata</string>
 
     <string name="label_watchonly">(solo-visualizzazione)</string>
@@ -136,11 +130,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s non confermati</string>
 
-    <string name="service_description">Servizio monerujo</string>
 
     <string name="status_synced">Sincronizzati:</string>
     <string name="status_remaining">Blocchi rimanenti</string>
-    <string name="status_syncing">Scansionando:</string>
 
     <string name="message_camera_not_permitted">Nessuna telecamera = Nessuna scansione QR!</string>
 
@@ -364,7 +356,6 @@
     <string name="onboarding_seed_title">Tieni al sicuro il tuo seed</string>
     <string name="onboarding_seed_information">Il seed permette l\'accesso al portafogli a chiunque lo abbia. Se lo perdi, non possiamo aiutarti a recuperarlo.</string>
     <string name="onboarding_xmrto_title">Invia altre crypto</string>
-    <string name="onboarding_xmrto_information">Monerujo supporta exchange. Copia o scansiona un indirizzo BTC, LTC, ETH, TRXUSDT o SOL per inviare una di queste crypto spendendo XMR.</string>
     <string name="onboarding_nodes_title">Nodi, a modo tuo</string>
     <string name="onboarding_nodes_information">I nodi ti connettono alla rete di Monero. Scegli tra i vari nodi pubblici oppure usa il tuo.</string>
     <string name="onboarding_fpsend_title">Invia con impronta</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@
 
     <string name="label_receive_info_gen_qr_code">タッチしてQRコードを表示</string>
 
-    <string name="info_xmrto_enabled">BTC支払いは有効化されています。詳細はタップしてください。</string>
     <string name="info_ledger_enabled">レッジャーは有効化されています。詳細はタップしてください。</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -73,9 +72,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(レート: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">サポートと追跡については %1$s をご覧ください</string>
-    <string name="label_send_btc_xmrto_key_lb">シークレットキー\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s のシークレットキー</string>
     <string name="label_send_btc_address">支払先の %1$s アドレス</string>
     <string name="label_send_btc_amount">数量</string>
 
@@ -95,7 +91,6 @@
     <string name="changepw_failed">パスワード変更に失敗しました!</string>
     <string name="changepw_success">パスワードが変更されました</string>
 
-    <string name="label_daemon">ノード</string>
     <string name="connect_stagenet" translatable="false">ステージネット</string>
     <string name="connect_testnet" translatable="false">テストネット</string>
     <string name="status_wallet_loading">ウォレットをロード中 &#8230;</string>
@@ -136,11 +131,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s が未承認</string>
 
-    <string name="service_description">monerujo のサービス</string>
 
     <string name="status_synced">同期済み:</string>
     <string name="status_remaining">残りのブロック</string>
-    <string name="status_syncing">スキャン中:</string>
 
     <string name="message_camera_not_permitted">カメラがありません = QRコードのスキャニングもできません!</string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Trykk for QR kode</string>
 
-    <string name="info_xmrto_enabled">BTC betaling tilgjengelig, trykk for mer info.</string>
     <string name="info_ledger_enabled">Ledger tilgjengelig, trykk for mer info.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -73,9 +72,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rate: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Besøk %1$s for støtte og sporing</string>
-    <string name="label_send_btc_xmrto_key_lb">Hemmelig nøkkel\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Hemmelig nøkkel</string>
     <string name="label_send_btc_address">%1$s destinasjonsadresse</string>
     <string name="label_send_btc_amount">Mengde</string>
 
@@ -96,7 +92,6 @@
     <string name="changepw_failed">[Passordforandring feila!]</string>
     <string name="changepw_success">[Passord forandra]</string>
 
-    <string name="label_daemon">Node</string>
     <string name="status_wallet_loading">Laster lommebok &#8230;</string>
     <string name="status_wallet_unloaded">Lommebok lagra</string>
     <string name="status_wallet_unload_failed">Lommeboklagring feila!</string>
@@ -124,7 +119,6 @@
     <string name="bad_password">Feil passord!</string>
     <string name="bad_saved_password">[Saved password is incorrect.\nPlease enter password manually.]</string>
     <string name="bad_wallet">Lommebok eksisterer ikke!</string>
-    <string name="prompt_daemon_missing">Daemon-adresse må være gitt!</string>
     <string name="prompt_wrong_net">Lommebok matcher ikke valgt nett</string>
 
     <string name="label_watchonly">(Bare se)</string>
@@ -134,11 +128,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s ubekrefta</string>
 
-    <string name="service_description">monerujo tjeneste</string>
 
     <string name="status_synced">Synkronisert:</string>
     <string name="status_remaining">Gjenværende blokker</string>
-    <string name="status_syncing">Skanner:</string>
 
     <string name="message_camera_not_permitted">Ikke noe kamera = ikke noe QR-skanning!</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Tik voor QR-code</string>
 
-    <string name="info_xmrto_enabled">BTC-betaling ingeschakeld. Tik voor meer info.</string>
     <string name="info_ledger_enabled">Ledger ingeschakeld. Tik voor meer info.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Koers: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Ga naar %1$s voor hulp en traceren</string>
-    <string name="label_send_btc_xmrto_key_lb">Geheime sleutel\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Geheime sleutel %1$s</string>
     <string name="label_send_btc_address">%1$s-doeladres</string>
     <string name="label_send_btc_amount">Bedrag</string>
 
@@ -96,7 +92,6 @@
     <string name="changepw_failed">Wachtwoord wijzigen mislukt!</string>
     <string name="changepw_success">Wachtwoord is gewijzigd</string>
 
-    <string name="label_daemon">Node</string>
     <string name="status_wallet_loading">Portemonnee laden…</string>
     <string name="status_wallet_unloaded">Portemonnee opgeslagen</string>
     <string name="status_wallet_unload_failed">Portemonnee opslaan mislukt!</string>
@@ -134,11 +129,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s onbevestigd</string>
 
-    <string name="service_description">monerujo-service</string>
 
     <string name="status_synced">Gesynchroniseerd:</string>
     <string name="status_remaining">Blokken te gaan</string>
-    <string name="status_syncing">Scannen:</string>
 
     <string name="message_camera_not_permitted">Geen camera = geen QR-codes scannen!</string>
 
@@ -225,7 +218,6 @@
 
     <string name="send_create_tx_error_title">Fout bij transactie maken</string>
 
-    <string name="tx_list_fee">kosten %1$s</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">mislukt</string>
     <string name="tx_list_amount_negative">- %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -24,14 +24,13 @@
     <string name="label_ok">OK</string>
     <string name="label_cancel">Cancelar</string>
     <string name="label_close">Fechar</string>
-    <string name="label_wallet_advanced_details">Mais detalhes</string> <!-- FUZZY -->
+    <string name="label_wallet_advanced_details">Mais detalhes</string>
 
     <string name="label_send_success">Enviado com sucesso</string>
     <string name="label_send_done">Concluído</string>
 
     <string name="label_receive_info_gen_qr_code">Toque para ver o código QR</string>
 
-    <string name="info_xmrto_enabled">Pagamento em BTC ativado, toque para mais informações.</string> <!-- FUZZY -->
     <string name="info_ledger_enabled">Ledger ativada, toque para mais informações.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Cotação: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Visite %1$s para suporte &amp; rastreio da ordem</string> <!-- FUZZY-INCORRECT -->
-    <string name="label_send_btc_xmrto_key_lb">Chave secreta\n%1$s</string> <!-- FUZZY-INCORRECT -->
-    <string name="label_send_btc_xmrto_key">Chave secreta %1$s</string> <!-- FUZZY-INCORRECT -->
     <string name="label_send_btc_address">Endereço %1$s de destino</string>
     <string name="label_send_btc_amount">Valor</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Erro ao alterar senha!</string>
     <string name="changepw_success">Senha alterada</string>
 
-    <string name="label_daemon">Nó</string> <!-- FUZZY-INCORRECT -->
     <string name="status_wallet_loading">Carregando &#8230;</string>
     <string name="status_wallet_unloaded">Carteira salva</string>
     <string name="status_wallet_unload_failed">Erro ao salvar carteira</string>
@@ -126,7 +121,6 @@
     <string name="bad_password">Senha incorreta!</string>
     <string name="bad_saved_password">A senha salva está incorreta.\nPor favor, escreva manualmente.</string>
     <string name="bad_wallet">Essa carteira não existe!</string>
-    <string name="prompt_daemon_missing">É preciso definir o endereço do daemon!</string> <!-- FUZZY -->
     <string name="prompt_wrong_net">A carteira não é compatível com a rede selecionada</string>
 
     <string name="label_watchonly">(Somente Leitura)</string>
@@ -136,11 +130,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s não confirmado</string>
 
-    <string name="service_description">Serviço monerujo</string> <!-- FUZZY -->
 
     <string name="status_synced">Sincronizado:</string>
     <string name="status_remaining">Blocos restantes</string>
-    <string name="status_syncing">Escaneando:</string> <!-- FUZZY -->
 
     <string name="message_camera_not_permitted">Sem câmera = Impossível escanear códigos QR!</string>
 
@@ -228,7 +220,6 @@
 
     <string name="send_create_tx_error_title">Erro ao criar a transação</string>
 
-    <string name="tx_list_fee">taxa de %1$s</string> <!-- FUZZY -->
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">falhou</string>
     <string name="tx_list_amount_negative">- %1$s</string>
@@ -354,7 +345,6 @@ aqui.</string>
     <string name="onboarding_seed_title">Mantenha sua semente em segurança</string>
     <string name="onboarding_seed_information">A semente dá acesso total a qualquer pessoa que a tenha. Se você perdê-la, nós não conseguiremos lhe ajudar a recuperá-la e você perderá seus amados moneroj.</string>
     <string name="onboarding_xmrto_title">Enviar Cripto</string>
-    <string name="onboarding_xmrto_information">A Monerujo possui o exchange integrado. Basta colar ou escanear um endereço BTC, LTC, ETH, TRXUSDT ou SOL e você estará enviando cripto, mas gastando em XMR.</string> <!-- FUZZY -->
     <string name="onboarding_nodes_title">"Nós", do seu jeito</string>
     <string name="onboarding_nodes_information">Os nós conectam você à rede Monero. Escolha entre nós públicos ou seja completamente "cypherpunk" e utilize seu próprio nó.</string>
     <string name="onboarding_fpsend_title">Enviar usando a digital</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <string name="wallet_activity_name">Carteira</string>
 
     <string name="menu_about">Sobre</string>
@@ -23,14 +24,14 @@
     <string name="label_ok">OK</string>
     <string name="label_cancel">Cancelar</string>
     <string name="label_close">Fechar</string>
-    <string name="label_wallet_advanced_details">Mais detalhes</string>
+    <string name="label_wallet_advanced_details">Mais detalhes</string> <!-- FUZZY -->
 
     <string name="label_send_success">Enviado com sucesso</string>
     <string name="label_send_done">Concluído</string>
 
     <string name="label_receive_info_gen_qr_code">Toque para ver o código QR</string>
 
-    <string name="info_xmrto_enabled">Pagamento em BTC ativado, toque para mais informações.</string>
+    <string name="info_xmrto_enabled">Pagamento em BTC ativado, toque para mais informações.</string> <!-- FUZZY -->
     <string name="info_ledger_enabled">Ledger ativada, toque para mais informações.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +75,9 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Cotação: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Visite %1$s para suporte &amp; rastreio da ordem</string>
-    <string name="label_send_btc_xmrto_key_lb">Chave secreta\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Chave secreta %1$s</string>
+    <string name="label_send_btc_xmrto_info">Visite %1$s para suporte &amp; rastreio da ordem</string> <!-- FUZZY-INCORRECT -->
+    <string name="label_send_btc_xmrto_key_lb">Chave secreta\n%1$s</string> <!-- FUZZY-INCORRECT -->
+    <string name="label_send_btc_xmrto_key">Chave secreta %1$s</string> <!-- FUZZY-INCORRECT -->
     <string name="label_send_btc_address">Endereço %1$s de destino</string>
     <string name="label_send_btc_amount">Valor</string>
 
@@ -96,7 +97,7 @@
     <string name="changepw_failed">Erro ao alterar senha!</string>
     <string name="changepw_success">Senha alterada</string>
 
-    <string name="label_daemon">Nó</string>
+    <string name="label_daemon">Nó</string> <!-- FUZZY-INCORRECT -->
     <string name="status_wallet_loading">Carregando &#8230;</string>
     <string name="status_wallet_unloaded">Carteira salva</string>
     <string name="status_wallet_unload_failed">Erro ao salvar carteira</string>
@@ -125,7 +126,7 @@
     <string name="bad_password">Senha incorreta!</string>
     <string name="bad_saved_password">A senha salva está incorreta.\nPor favor, escreva manualmente.</string>
     <string name="bad_wallet">Essa carteira não existe!</string>
-    <string name="prompt_daemon_missing">É preciso definir o endereço do daemon!</string>
+    <string name="prompt_daemon_missing">É preciso definir o endereço do daemon!</string> <!-- FUZZY -->
     <string name="prompt_wrong_net">A carteira não é compatível com a rede selecionada</string>
 
     <string name="label_watchonly">(Somente Leitura)</string>
@@ -135,11 +136,11 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s não confirmado</string>
 
-    <string name="service_description">Serviço monerujo</string>
+    <string name="service_description">Serviço monerujo</string> <!-- FUZZY -->
 
     <string name="status_synced">Sincronizado:</string>
     <string name="status_remaining">Blocos restantes</string>
-    <string name="status_syncing">Escaneando:</string>
+    <string name="status_syncing">Escaneando:</string> <!-- FUZZY -->
 
     <string name="message_camera_not_permitted">Sem câmera = Impossível escanear códigos QR!</string>
 
@@ -227,7 +228,7 @@
 
     <string name="send_create_tx_error_title">Erro ao criar a transação</string>
 
-    <string name="tx_list_fee">taxa de %1$s</string>
+    <string name="tx_list_fee">taxa de %1$s</string> <!-- FUZZY -->
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">falhou</string>
     <string name="tx_list_amount_negative">- %1$s</string>
@@ -353,7 +354,7 @@ aqui.</string>
     <string name="onboarding_seed_title">Mantenha sua semente em segurança</string>
     <string name="onboarding_seed_information">A semente dá acesso total a qualquer pessoa que a tenha. Se você perdê-la, nós não conseguiremos lhe ajudar a recuperá-la e você perderá seus amados moneroj.</string>
     <string name="onboarding_xmrto_title">Enviar Cripto</string>
-    <string name="onboarding_xmrto_information">A Monerujo possui o exchange integrado. Basta colar ou escanear um endereço BTC, LTC, ETH, TRXUSDT ou SOL e você estará enviando cripto, mas gastando em XMR.</string>
+    <string name="onboarding_xmrto_information">A Monerujo possui o exchange integrado. Basta colar ou escanear um endereço BTC, LTC, ETH, TRXUSDT ou SOL e você estará enviando cripto, mas gastando em XMR.</string> <!-- FUZZY -->
     <string name="onboarding_nodes_title">"Nós", do seu jeito</string>
     <string name="onboarding_nodes_information">Os nós conectam você à rede Monero. Escolha entre nós públicos ou seja completamente "cypherpunk" e utilize seu próprio nó.</string>
     <string name="onboarding_fpsend_title">Enviar usando a digital</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Toca para código QR</string>
 
-    <string name="info_xmrto_enabled">Pagamento em BTC activado, toca para mais informação.</string>
     <string name="info_ledger_enabled">Ledger activa, toca para mais informação.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rácio: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Vai a %1$s para suporte &amp; seguimento</string>
-    <string name="label_send_btc_xmrto_key_lb">Chave secreta\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Chave secreta</string>
     <string name="label_send_btc_address">Endereço %1$s de destino</string>
     <string name="label_send_btc_amount">Quantidade</string>
 
@@ -96,7 +92,6 @@
     <string name="changepw_failed">Erro ao alterar a palavra passe!</string>
     <string name="changepw_success">Palavra passe alterada</string>
 
-    <string name="label_daemon">Nó</string>
     <string name="status_wallet_loading">A carregar a carteira &#8230;</string>
     <string name="status_wallet_unloaded">Carteira guardada</string>
     <string name="status_wallet_unload_failed">Erro ao gravar a carteira!</string>
@@ -122,7 +117,6 @@
     <string name="bad_fingerprint">Impressão diginal não reconhecida. Tenta novamente.</string>
     <string name="bad_password">Palavra passe incorrecta!</string>
     <string name="bad_wallet">A carteira não existe!</string>
-    <string name="prompt_daemon_missing">O endereço do serviço tem que estar definido!</string>
     <string name="prompt_wrong_net">A carteira não combina com a rede seleccionada</string>
 
     <string name="label_watchonly">(Ver apenas)</string>
@@ -132,11 +126,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s não confirmado</string>
 
-    <string name="service_description">Serviço monerujo</string>
 
     <string name="status_synced">Sincronizado:</string>
     <string name="status_remaining">Blocos remanescentes</string>
-    <string name="status_syncing">A examinar:</string>
 
     <string name="message_camera_not_permitted">Sem câmara = Sem códigos QR!</string>
 

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -29,7 +29,6 @@
 
     <string name="label_receive_info_gen_qr_code">Atinge pentru codul QR</string>
 
-    <string name="info_xmrto_enabled">Plată BTC activată, apasă pentru mai multe informații.</string>
     <string name="info_ledger_enabled">Ledger activată, apasă pentru mai multe informații.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -73,9 +72,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rată: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Vizitează %1$s pentru suport &amp; interogare</string>
-    <string name="label_send_btc_xmrto_key_lb">Cheia secretă \n%1$s</string>
-    <string name="label_send_btc_xmrto_key">Cheia secretă %1$s</string>
     <string name="label_send_btc_address">Destinație adresă %1$s</string>
     <string name="label_send_btc_amount">Sumă</string>
 
@@ -93,7 +89,6 @@
     <string name="backup_failed">Copia de rezervă a eșuat!</string>
     <string name="rename_failed">Redenumirea a eșuat!</string>
 
-    <string name="label_daemon">Nodul</string>
     <string name="status_wallet_loading">Se încarcă portofelul &#8230;</string>
     <string name="status_wallet_unloaded">Portofelul a fost salvat</string>
     <string name="status_wallet_unload_failed">Salvarea portofelului a eșuat!</string>
@@ -125,11 +120,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s neconfirmat</string>
 
-    <string name="service_description">Serviciul monerujo</string>
 
     <string name="status_synced">Sincronizat:</string>
     <string name="status_remaining">Monoblocuri rămase</string>
-    <string name="status_syncing">Scanare:</string>
 
     <string name="message_camera_not_permitted">Fără cameră = Fără scanare coduri QR!</string>
 
@@ -360,7 +353,6 @@
     <string name="onboarding_seed_title">Păstrează semnătura ta în singuranță</string>
     <string name="onboarding_seed_information">Semnătura oferă accces deplin celui ce o are. Dacă o pierzi, nu te putem ajuta să o recuperezi și pierzi dulcii tăi moneroj.</string>
     <string name="onboarding_xmrto_title">Trimite Cripto</string>
-    <string name="onboarding_xmrto_information">Monerujo are integrat serviciul exchange. Doar inserează sau scanează o adresă BTC, LTC, ETH, TRXUSDT sau SOL și vei trimite aceste monede cu XMR.</string>
     <string name="onboarding_nodes_title">Noduri, cum îți dorești</string>
     <string name="onboarding_nodes_information">Nodurile te conectează la rețeaua Monero. Alege între noduri publice sau fii un cypherpunk și pornește unul propriu.</string>
     <string name="onboarding_fpsend_title">Trimite cu amprentă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Нажмите для использования QR-кода</string>
 
-    <string name="info_xmrto_enabled">Доступны переводы в BTC, нажмите для доп. информации</string>
     <string name="info_ledger_enabled">Доступен Ledger, нажмите для доп. информации</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Курс: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Посетите %1$s для получения помощи &amp;</string>
-    <string name="label_send_btc_xmrto_key_lb">Секретный ключ\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s секретный ключ</string>
     <string name="label_send_btc_address">Адрес получателя %1$s</string>
     <string name="label_send_btc_amount">Сумма</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Изменение пароля произошло с ошибкой!</string>
     <string name="changepw_success">Изменение пароля выполено успешно</string>
 
-    <string name="label_daemon">Удаленный узел</string>
     <string name="status_wallet_loading">Загрузка кошелька &#8230;</string>
     <string name="status_wallet_unloaded">Кошелек записан</string>
     <string name="status_wallet_unload_failed">Ошибка записи кошелека!</string>
@@ -135,11 +130,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s не подтверждено</string>
 
-    <string name="service_description">Служба Monerujo</string>
 
     <string name="status_synced">Синхронизировано:</string>
     <string name="status_remaining">Блоков осталось</string>
-    <string name="status_syncing">Просканировано:</string>
 
     <string name="message_camera_not_permitted">Нет доступа к камере = Нет QR-сканирования!</string>
 
@@ -365,7 +358,6 @@
     <string name="onboarding_seed_title">Храните свои ключи в безопасности</string>
     <string name="onboarding_seed_information">Секретная фраза дает полный доступ к кошельку. Если вы её потеряете, мы не сможем её восстановить и вы потеряете ваши moneroj.</string>
     <string name="onboarding_xmrto_title">Отправка других криптовалют</string>
-    <string name="onboarding_xmrto_information">Monerujo имеет поддержку exchange. Просто вставьте (или просканируйте) адрес BTC, LTC, ETH, TRXUSDT или SOL и вы будете отправлять эти криптовалюты, тратя XMR.</string>
     <string name="onboarding_nodes_title">Узлы, узлы, узлы…</string>
     <string name="onboarding_nodes_information">Узлы позволяют подключаться к сети Monero. Выбирайте между общедоступными узлами или используйте свой собственный для безопасности IP адреса.</string>
     <string name="onboarding_fpsend_title">Отправка с помощью отпечатка пальца</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Klepni pre QR kód</string>
 
-    <string name="info_xmrto_enabled">BTC platby aktivované, klepni pre viac info.</string>
     <string name="info_ledger_enabled">Ledger aktivovaný, klepni pre viac info.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Kurz: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Navštív %1$s pre podporu &amp; tracking</string>
-    <string name="label_send_btc_xmrto_key_lb">Tajný kľúč\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Tajný kľúč</string>
     <string name="label_send_btc_address">Cieľová %1$s Adresa</string>
     <string name="label_send_btc_amount">Čiastka</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Zmena hesla zlyhala!</string>
     <string name="changepw_success">Heslo zmenené</string>
 
-    <string name="label_daemon">Uzol</string>
     <string name="status_wallet_loading">Načítavam peňaženku &#8230;</string>
     <string name="status_wallet_unloaded">Peňaženka uložená</string>
     <string name="status_wallet_unload_failed">Uloženie zlyhalo!</string>
@@ -135,11 +130,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s nepotvrdených</string>
 
-    <string name="service_description">monerujo Service</string>
 
     <string name="status_synced">Synchronizované:</string>
     <string name="status_remaining">zostávajúcich blokov</string>
-    <string name="status_syncing">Skenovanie:</string>
 
     <string name="message_camera_not_permitted">Bez kamery = žiaden QR kód!</string>
 

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Takni za QR kod</string>
 
-    <string name="info_xmrto_enabled">Omogućeno BTC plaćanje, tapni za više info.</string>
     <string name="info_ledger_enabled">Knjiga računa omogućena, tapni za više info.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rate: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Poseti %1$s za bekap &amp; praćenje</string>
-    <string name="label_send_btc_xmrto_key_lb">Tajna šifra\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s Tajna šifra</string>
     <string name="label_send_btc_address">Odredište %1$s adrese</string>
     <string name="label_send_btc_amount">Suma</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Promena lozinke neuspela!</string>
     <string name="changepw_success">Lozinka promenjena</string>
 
-    <string name="label_daemon">Čvor</string>
 
     <string name="status_wallet_loading">Otvaranje novčanika &#8230;</string>
     <string name="status_wallet_unloaded">Novčanik sačuvan</string>
@@ -137,11 +132,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s nepotvrđeno</string>
 
-    <string name="service_description">monerujo Servis</string>
 
     <string name="status_synced">Sinhronizovano:</string>
     <string name="status_remaining">Preostali blokovi</string>
-    <string name="status_syncing">Skeniranje:</string>
 
     <string name="message_camera_not_permitted">Nema kamere = Nema QR skeniranja!</string>
 
@@ -235,7 +228,6 @@
 
     <string name="send_create_tx_error_title">Kreiraj transakcijsku grešku</string>
 
-    <string name="tx_list_fee">naknada %1$s</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">neuspelo</string>
     <string name="tx_list_amount_negative">- %1$s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Tryck för QR-kod</string>
 
-    <string name="info_xmrto_enabled">BTC-betalning aktiverad, tryck för mer info.</string>
     <string name="info_ledger_enabled">Ledger aktiverat, tryck för mer info.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Kurs: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Besök %1$s för support &amp; spårning</string>
-    <string name="label_send_btc_xmrto_key_lb">Hemlig nyckel\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s hemlig nyckel</string>
     <string name="label_send_btc_address">Måladress för %1$s</string>
     <string name="label_send_btc_amount">Belopp</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Det gick inte att ändra lösenord!</string>
     <string name="changepw_success">Lösenordet har ändrats</string>
 
-    <string name="label_daemon">Nod</string>
     <string name="status_wallet_loading">Läser in plånbok …</string>
     <string name="status_wallet_unloaded">Plånbok sparad</string>
     <string name="status_wallet_unload_failed">Det gick inte att spara plånbok!</string>
@@ -133,11 +128,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s obekräftade</string>
 
-    <string name="service_description">monerujo-tjänsten</string>
 
     <string name="status_synced">Synkade:</string>
     <string name="status_remaining">Återstående block</string>
-    <string name="status_syncing">Skannar:</string>
 
     <string name="message_camera_not_permitted">Ingen kamera = Ingen QR-skanning!</string>
 
@@ -352,7 +345,6 @@
     <string name="onboarding_seed_title">Håll dina seed i säkert förvar.</string>
     <string name="onboarding_seed_information">Seed ger full åtkomst till den som har den. Om du förlorar det, kan vi inte hjälpa dig och du förlorar dina kära moneroj.</string>
     <string name="onboarding_xmrto_title">Skicka krypto</string>
-    <string name="onboarding_xmrto_information">Monerujo har exchange support inbyggt. Bara klistra in eller scanna en BTC, LTC, ETH, TRXUSDT or SOL address och du skickar dessa krypto genom att spendera XMR.</string>
     <string name="onboarding_nodes_title">Noder, på ditt sätt.</string>
     <string name="onboarding_nodes_information">Noder ansluter dig till Monero-nätverket. Välj mellan offentliga noder eller gå all-in "cypherpunk" med din egen.</string>
     <string name="onboarding_fpsend_title">Skicka med fingeravtryck</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -31,7 +31,6 @@
 
     <string name="label_receive_info_gen_qr_code">QR குறியீட்டிற்கு தொடவும்</string>
 
-    <string name="info_xmrto_enabled">XMR-அல்லாத பணம் செலுத்தல் செயல்படுத்தப்பட்டுள்ளது, மேலும் விவரங்களுக்கு தட்டவும்.</string>
     <string name="info_ledger_enabled">பேரேடு செயல்படுத்தப்பட்டுள்ளது, மேலும் விவரங்களுக்கு தட்டவும்.</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(விலை: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">ஆதரவு &amp; சுவடுபற்றிச் செல்லலுக்கு %1$s பக்கத்தை பார்க்கவும்</string>
-    <string name="label_send_btc_xmrto_key_lb">இரகசிய திறவுகோல்\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s இரகசிய திறவுகோல்</string>
     <string name="label_send_btc_address">சேருமிட %1$s முகவரி</string>
     <string name="label_send_btc_amount">தொகை</string>
 
@@ -99,7 +95,6 @@
     <string name="changepw_failed">கடவுச்சொல் மாற்றம் தோல்வியடைந்தது!</string>
     <string name="changepw_success">கடவுச்சொல் மாற்றப்பட்டது</string>
 
-    <string name="label_daemon">வலையமைப்பு</string>
     <string name="status_wallet_loading">&#8230; பணப்பை ஏறுகிறது</string>
     <string name="status_wallet_unloaded">பணப்பை சேமிக்கப்பட்டது</string>
     <string name="status_wallet_unload_failed">பணப்பை சேமித்தல் தோல்வியடைந்தது!</string>
@@ -138,11 +133,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s உறுதிப்படுத்தப்படவில்லை</string>
 
-    <string name="service_description">monerujo சேவை</string>
 
     <string name="status_synced">ஒத்திசைக்கப்பட்டது:</string>
     <string name="status_remaining">மீதமுள்ள தொகுதிகள்</string>
-    <string name="status_syncing">வருடுகிறது:</string>
 
     <string name="message_camera_not_permitted">படமி இல்லையென்றால் QR வருடலும் இல்லை</string>
 
@@ -237,7 +230,6 @@
 
     <string name="send_create_tx_error_title">பரிமாற்ற உருவாக்கல் பிழை</string>
 
-    <string name="tx_list_fee">கட்டணம் %1$s</string>
     <string name="tx_list_amount_failed">(%1$s)</string>
     <string name="tx_list_failed_text">தோல்வியடைந்தது</string>
     <string name="tx_list_amount_negative">- %1$s</string>
@@ -362,7 +354,6 @@
     <string name="onboarding_seed_title">விதையை பாதுகாப்பாக வைக்கவும்</string>
     <string name="onboarding_seed_information">இந்த விதை அதை வைத்திருப்பவருக்கு முழு அணுகலை வழங்குகிறது. இதை நீங்கள் துலைத்து விட்டால், இதை மீட்க எங்களால் உங்களுக்கு உதவ இயலாது. உங்கள் மனம் கவர்ந்த மொனேரொக்களை இழக்க நேரிடும்.</string>
     <string name="onboarding_xmrto_title">கிரிப்டோவை அனுப்பவும்</string>
-    <string name="onboarding_xmrto_information">Monerujo இனுள் exchange க்கான ஆதரவு உட்பொதிந்துள்ளது. வெறும் BTC, LTC, ETH, TRXUSDT அல்லது SOL க்கான முகவரியை ஒட்டுவதன் மூலம் அல்லது வருடுவதன் மூலம் உங்களால் XMR ஐ செலவழித்து இந்தவகை கிரிப்டோக்களாக அனுப்ப இயலும்.</string>
     <string name="onboarding_nodes_title">கணுக்கள், இது உங்கள் வழி</string>
     <string name="onboarding_nodes_information">கணுக்கள் உங்களை மொனேரொ வலையமைப்போடு இணைக்கிறது. பொது கணுக்களை பயன்படுத்துகிறீர்களா அல்லது முழுவதுமாக உங்கள் சொந்த கணுவை பயன்படுத்த போகிறீர்களா என்பதை முடிவு செய்யவும்.</string>
     <string name="onboarding_fpsend_title">விரல்பதிவை கொண்டு அனுப்பவும்</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -79,9 +79,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Oran: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Destek ve takip için borsa sitesini ziyaret edin</string>
-    <string name="label_send_btc_xmrto_key_lb">Sipariş numarası\nBorsa</string>
-    <string name="label_send_btc_xmrto_key">Borsa sipariş numarası</string>
     <string name="label_send_btc_address">Hedef %1$s Adresi</string>
     <string name="label_send_btc_amount">Meblağ</string>
 
@@ -103,7 +100,6 @@
     <string name="changepw_failed">Parola değişimi başarısız oldu!</string>
     <string name="changepw_success">Parola değiştirildi</string>
 
-    <string name="label_daemon">Şebeke</string>
 
     <string name="status_wallet_loading">Cüzdan yükleniyor &#8230;</string>
     <string name="status_wallet_unloaded">Cüzdan kaydedildi</string>
@@ -147,7 +143,6 @@
 
     <string name="status_synced">Eşleşmiş:</string>
     <string name="status_remaining">Blok kaldı</string>
-    <string name="status_syncing">Eşleşiyor:</string>
 
     <string name="message_camera_not_permitted">Kamera yok = QR taraması yok!</string>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -30,7 +30,6 @@
 
     <string name="label_receive_info_gen_qr_code">Натисніть для використання QR-коду</string>
 
-    <string name="info_xmrto_enabled">Доступні перекази в BTC, натисніть для доп. інформації</string>
     <string name="info_ledger_enabled">Доступний Ledger, натисніть для доп. інформації</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -75,9 +74,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Курс: %1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">Відвідайте %1$s для отримання допомоги &amp;</string>
-    <string name="label_send_btc_xmrto_key_lb">Секретний ключ\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s секретний ключ</string>
     <string name="label_send_btc_address">Адреса отримувача %1$s</string>
     <string name="label_send_btc_amount">Сума</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">Зміна паролю відбулася з помилкою!</string>
     <string name="changepw_success">Зміну паролю виконано успішно</string>
 
-    <string name="label_daemon">Віддалений вузол</string>
     <string name="status_wallet_loading">Завантаження гаманця &#8230;</string>
     <string name="status_wallet_unloaded">Гаманець збережено</string>
     <string name="status_wallet_unload_failed">Помилка збереження гаманця!</string>
@@ -125,7 +120,6 @@
     <string name="bad_password">Невірний пароль!!</string>
     <string name="bad_saved_password">Збережений пароль невірний.\nВведіть пароль вручну.</string>
     <string name="bad_wallet">Гаманця не існує!</string>
-    <string name="prompt_daemon_missing">Повинна бути встановлена адреса віддаленого вузла!</string>
     <string name="prompt_wrong_net">Гаманець не відповідає обраній мережі</string>
 
     <string name="label_watchonly">(Режим перегляду)</string>
@@ -135,11 +129,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s непідтверджено</string>
 
-    <string name="service_description">Служба monerujo</string>
 
     <string name="status_synced">Синхронізовано:</string>
     <string name="status_remaining">Блоків залишилось</string>
-    <string name="status_syncing">Проскановано:</string>
 
     <string name="message_camera_not_permitted">Немає доступу до камери = Немає QR-сканування!</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -22,7 +22,6 @@
     <string name="label_send_success">发送成功</string>
     <string name="label_send_done">完成</string>
     <string name="label_receive_info_gen_qr_code">点此获取QR码</string>
-    <string name="info_xmrto_enabled">已支持比特币支付，点此了解更多</string>
     <string name="info_ledger_enabled">已支持Ledger硬件钱包，点此了解更多</string>
     <string name="info_xmrto"><![CDATA[
       <b>您输入了一个%1$s地址</b><br/>
@@ -53,9 +52,6 @@
     <string name="text_noretry">抱歉, %1$s服务现在似乎不可用</string>
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(Rate: %1$s %2$s/XMR)</string>
-    <string name="label_send_btc_xmrto_info">访问%1$s以获得更多支持</string>
-    <string name="label_send_btc_xmrto_key_lb">密钥\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s密钥</string>
     <string name="label_send_btc_address">%1$s收款地址</string>
     <string name="label_send_btc_amount">金额</string>
     <string name="label_send_txid">交易ID</string>
@@ -71,7 +67,6 @@
     <string name="rename_failed">重命名失败！</string>
     <string name="changepw_failed">密码修改失败！</string>
     <string name="changepw_success">密码已修改</string>
-    <string name="label_daemon">节点</string>
     <string name="status_wallet_loading">钱包加载中 &#8230;</string>
     <string name="status_wallet_unloaded">钱包已保存</string>
     <string name="status_wallet_unload_failed">钱包保存失败！</string>
@@ -100,10 +95,8 @@
     <string name="label_wallet_receive">收款</string>
     <string name="label_wallet_send">发送</string>
     <string name="xmr_unconfirmed_amount">+ %1$s %2$s未确认</string>
-    <string name="service_description">monerujo服务</string>
     <string name="status_synced">已同步：</string>
     <string name="status_remaining">区块剩余</string>
-    <string name="status_syncing">扫描中：</string>
     <string name="message_camera_not_permitted">不开通的相机权限的话便无法扫描QR码！</string>
     <string name="label_copy_viewkey">查阅密钥</string>
     <string name="label_copy_address">公开地址</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@
 
     <string name="label_receive_info_gen_qr_code">點選顯示 QR 碼</string>
 
-    <string name="info_xmrto_enabled">BTC 付款已啟用，點選了解更多</string>
     <string name="info_ledger_enabled">Ledger 已啟用，點選了解更多</string>
 
     <string name="info_xmrto"><![CDATA[
@@ -74,9 +73,6 @@
     <string name="text_send_btc_amount">%1$s %3$s = %2$s XMR</string>
     <string name="text_send_btc_rate">(匯率：%1$s %2$s/XMR)</string>
 
-    <string name="label_send_btc_xmrto_info">參訪 %1$s 以獲得支援及追蹤交易</string>
-    <string name="label_send_btc_xmrto_key_lb">私鑰\n%1$s</string>
-    <string name="label_send_btc_xmrto_key">%1$s 私鑰</string>
     <string name="label_send_btc_address">目的地 %1$s 地址</string>
     <string name="label_send_btc_amount">金額</string>
 
@@ -97,7 +93,6 @@
     <string name="changepw_failed">密碼更改失敗！</string>
     <string name="changepw_success">密碼更改成功</string>
 
-    <string name="label_daemon">節點</string>
     <string name="status_wallet_loading">載入錢包中 &#8230;</string>
     <string name="status_wallet_unloaded">錢包已儲存</string>
     <string name="status_wallet_unload_failed">儲存錢包失敗！</string>
@@ -135,11 +130,9 @@
 
     <string name="xmr_unconfirmed_amount">+ %1$s 未確認的 %2$s </string>
 
-    <string name="service_description">monerujo 服務</string>
 
     <string name="status_synced">已同步區塊：</string>
     <string name="status_remaining">剩餘區塊</string>
-    <string name="status_syncing">掃描中：</string>
 
     <string name="message_camera_not_permitted">沒有相機 = 不能掃描QR碼！</string>
 
@@ -358,7 +351,6 @@
     <string name="onboarding_seed_title">保管好你的種子碼</string>
     <string name="onboarding_seed_information">種子碼提供任何人完整的權限。如果你遺失了種子碼，我們無法幫你找回它，且你將失去你心愛的 moneroj。</string>
     <string name="onboarding_xmrto_title">發送加密貨幣</string>
-    <string name="onboarding_xmrto_information">Monerujo 內建 exchange 服務。只要貼上或掃描 BTC、LTC、ETH、TRXUSDT 或 SOL 地址，你就可以直接使用 XMR 來發送這些加密貨幣。</string>
     <string name="onboarding_nodes_title">節點選擇，由你作主</string>
     <string name="onboarding_nodes_information">你必須透過節點連線至 Monero 交易網路。選擇使用公共節點或是很密碼龐克式地使用你自己的節點。</string>
     <string name="onboarding_fpsend_title">使用指紋辨識發送交易</string>


### PR DESCRIPTION
Attempt at removing fuzzy translations, but a much more restrictive method to find them than git blaming everything

Process:
1. Detect weird translations
2. Check if they've been changed at source and that's the reason they're weird
3. Tag them as fuzzy
4. Search for that string in translations, check git blame for when they were last edited, if it's unclear, check it with google translate to see if the meaning matches somewhat, if not, wipe them, if yes, keep