### PR TITLE
Import Feather CSV transaction descriptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Download Dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew --no-daemon --max-workers=1 androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Run Tests
-          command: ./gradlew test
+          command: ./gradlew --no-daemon --max-workers=1 test
       - store_artifacts:
           path: app/build/reports
           destination: reports

--- a/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/WalletActivity.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -37,6 +38,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
@@ -63,13 +65,18 @@ import com.m2049r.xmrwallet.model.TransactionInfo;
 import com.m2049r.xmrwallet.model.Wallet;
 import com.m2049r.xmrwallet.model.WalletManager;
 import com.m2049r.xmrwallet.service.WalletService;
+import com.m2049r.xmrwallet.util.FeatherCsvTxNotes;
 import com.m2049r.xmrwallet.util.Helper;
 import com.m2049r.xmrwallet.util.MoneroThreadPoolExecutor;
 import com.m2049r.xmrwallet.util.ThemeHelper;
 import com.m2049r.xmrwallet.widget.Toolbar;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import timber.log.Timber;
@@ -93,6 +100,7 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
     public static final String REQUEST_STREETMODE = "streetmode";
     public static final String REQUEST_URI = "uri";
     public static final String REQUEST_SIDEKICK = "sidekick";
+    private static final int IMPORT_FEATHER_NOTES_INTENT = 1201;
 
     private NavigationView accountsView;
     private DrawerLayout drawer;
@@ -265,6 +273,8 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
         final int itemId = item.getItemId();
         if (itemId == R.id.action_rescan) {
             onWalletRescan();
+        } else if (itemId == R.id.action_import_feather_notes) {
+            onImportFeatherNotes();
         } else if (itemId == R.id.action_info) {
             onWalletDetails();
         } else if (itemId == R.id.action_share) {
@@ -294,6 +304,114 @@ public class WalletActivity extends BaseActivity implements WalletFragment.Liste
         } else
             return super.onOptionsItemSelected(item);
         return true;
+    }
+
+    private void onImportFeatherNotes() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
+                "text/*",
+                "text/csv",
+                "application/csv",
+                "application/vnd.ms-excel"
+        });
+        startActivityForResult(intent, IMPORT_FEATHER_NOTES_INTENT);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == IMPORT_FEATHER_NOTES_INTENT) {
+            if (resultCode == RESULT_OK && data != null && data.getData() != null) {
+                new AsyncImportFeatherNotes(data.getData())
+                        .executeOnExecutor(MoneroThreadPoolExecutor.MONERO_THREAD_POOL_EXECUTOR);
+            }
+        }
+    }
+
+    private static class ImportFeatherNotesResult {
+        final int imported;
+        final Exception error;
+
+        ImportFeatherNotesResult(int imported, Exception error) {
+            this.imported = imported;
+            this.error = error;
+        }
+    }
+
+    @SuppressLint("StaticFieldLeak")
+    private class AsyncImportFeatherNotes extends AsyncTask<Void, Void, ImportFeatherNotesResult> {
+        private final Uri csvUri;
+
+        AsyncImportFeatherNotes(Uri csvUri) {
+            this.csvUri = csvUri;
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            showProgressDialog(R.string.menu_import_feather_notes);
+        }
+
+        @Override
+        protected ImportFeatherNotesResult doInBackground(Void... params) {
+            try (InputStream inputStream = getContentResolver().openInputStream(csvUri)) {
+                if (inputStream == null) {
+                    throw new IllegalArgumentException("Selected file could not be opened");
+                }
+                FeatherCsvTxNotes.Result result = new FeatherCsvTxNotes()
+                        .parse(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+                int imported = importFeatherNotes(result.notes);
+                if (imported > 0) {
+                    saveWallet();
+                    getWallet().refreshHistory();
+                }
+                return new ImportFeatherNotesResult(imported, null);
+            } catch (Exception e) {
+                return new ImportFeatherNotesResult(0, e);
+            }
+        }
+
+        private int importFeatherNotes(Map<String, String> notes) {
+            int imported = 0;
+            Wallet wallet = getWallet();
+            for (Map.Entry<String, String> entry : notes.entrySet()) {
+                String existingTxNotes = wallet.getUserNote(entry.getKey());
+                UserNotes userNotes = new UserNotes(existingTxNotes);
+                userNotes.setNote(entry.getValue());
+                if (wallet.setUserNote(entry.getKey(), userNotes.txNotes)) {
+                    imported++;
+                }
+            }
+            return imported;
+        }
+
+        @Override
+        protected void onPostExecute(ImportFeatherNotesResult result) {
+            super.onPostExecute(result);
+            dismissProgressDialog();
+            if (result.error != null) {
+                String message = result.error.getLocalizedMessage();
+                if (message == null) {
+                    message = result.error.getClass().getSimpleName();
+                }
+                Toast.makeText(WalletActivity.this,
+                        getString(R.string.import_feather_notes_error, message),
+                        Toast.LENGTH_LONG).show();
+                return;
+            }
+            if (result.imported > 0) {
+                forceUpdate();
+                Toast.makeText(WalletActivity.this,
+                        getString(R.string.import_feather_notes_success, result.imported),
+                        Toast.LENGTH_LONG).show();
+            } else {
+                Toast.makeText(WalletActivity.this,
+                        getString(R.string.import_feather_notes_none),
+                        Toast.LENGTH_LONG).show();
+            }
+        }
     }
 
     private void updateStreetMode() {

--- a/app/src/main/java/com/m2049r/xmrwallet/util/FeatherCsvTxNotes.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/FeatherCsvTxNotes.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 m2049r
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.m2049r.xmrwallet.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class FeatherCsvTxNotes {
+    private static final String TXID = "txid";
+    private static final String DESCRIPTION = "description";
+
+    public static class Result {
+        public final Map<String, String> notes;
+        public final int rowsRead;
+        public final int rowsSkipped;
+
+        Result(Map<String, String> notes, int rowsRead, int rowsSkipped) {
+            this.notes = notes;
+            this.rowsRead = rowsRead;
+            this.rowsSkipped = rowsSkipped;
+        }
+    }
+
+    public Result parse(Reader reader) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(reader);
+        String headerLine = readRecord(bufferedReader);
+        if (headerLine == null) {
+            return new Result(new LinkedHashMap<>(), 0, 0);
+        }
+
+        List<String> headers = parseLine(stripBom(headerLine));
+        int txidColumn = columnIndex(headers, TXID);
+        int descriptionColumn = columnIndex(headers, DESCRIPTION);
+        if (txidColumn < 0 || descriptionColumn < 0) {
+            throw new IOException("CSV must include txid and description columns");
+        }
+
+        Map<String, String> notes = new LinkedHashMap<>();
+        int rowsRead = 0;
+        int rowsSkipped = 0;
+        String line;
+        while ((line = readRecord(bufferedReader)) != null) {
+            rowsRead++;
+            List<String> columns = parseLine(line);
+            String txid = getColumn(columns, txidColumn).trim();
+            String description = getColumn(columns, descriptionColumn).trim();
+            if (txid.isEmpty() || description.isEmpty()) {
+                rowsSkipped++;
+                continue;
+            }
+            notes.put(txid, description);
+        }
+        return new Result(notes, rowsRead, rowsSkipped);
+    }
+
+    private String readRecord(BufferedReader reader) throws IOException {
+        StringBuilder record = new StringBuilder();
+        boolean quoted = false;
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+            if (record.length() > 0) {
+                record.append('\n');
+            }
+            record.append(line);
+
+            for (int i = 0; i < line.length(); i++) {
+                char c = line.charAt(i);
+                if (c == '"') {
+                    if (quoted && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        i++;
+                    } else {
+                        quoted = !quoted;
+                    }
+                }
+            }
+
+            if (!quoted) {
+                return record.toString();
+            }
+        }
+
+        if (record.length() == 0) {
+            return null;
+        }
+        throw new IOException("Unclosed quoted CSV field");
+    }
+
+    private int columnIndex(List<String> headers, String name) {
+        for (int i = 0; i < headers.size(); i++) {
+            if (name.equals(headers.get(i).trim().toLowerCase(Locale.US))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String getColumn(List<String> columns, int index) {
+        if (index >= columns.size()) {
+            return "";
+        }
+        return columns.get(index);
+    }
+
+    private static String stripBom(String value) {
+        if (!value.isEmpty() && value.charAt(0) == '\ufeff') {
+            return value.substring(1);
+        }
+        return value;
+    }
+
+    private static List<String> parseLine(String line) throws IOException {
+        List<String> result = new ArrayList<>();
+        StringBuilder value = new StringBuilder();
+        boolean quoted = false;
+
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '"') {
+                if (quoted && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                    value.append('"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+            } else if (c == ',' && !quoted) {
+                result.add(value.toString());
+                value.setLength(0);
+            } else {
+                value.append(c);
+            }
+        }
+
+        if (quoted) {
+            throw new IOException("Unclosed quoted CSV field");
+        }
+
+        result.add(value.toString());
+        return result;
+    }
+}

--- a/app/src/main/res/menu/wallet_menu.xml
+++ b/app/src/main/res/menu/wallet_menu.xml
@@ -35,6 +35,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_import_feather_notes"
+        android:orderInCategory="650"
+        android:title="@string/menu_import_feather_notes"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_subaddresses"
         android:orderInCategory="700"
         android:title="@string/subbaddress_title"

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -360,7 +360,7 @@
     <string name="menu_close">மூடு</string>
     <string name="pocketchange_info">மீண்டும் மீண்டும் செலவழிக்க காத்திருக்கும் நேரத்தைக் குறைக்க, அதிக கட்டணங்களின் இழப்பில் மோனெருசோ உதிரி மாற்றத்தை உருவாக்க முடியும். இது தேர்ந்தெடுக்கப்பட்ட தொகையில் குறைந்தது 6 நாணயங்களை உருவாக்கி பராமரிக்க முயற்சிக்கும்.</string>
     <string name="message_qr_failed">பகிர்வதற்கு QR ஐ உருவாக்கத் தவறிவிட்டது!</string>
-    <string name="tx_locked">பரிவர்த்தனை தொகை தொகுதி %1$d வரை பூட்டப்பட்டுள்ளது ( %2$d தொகுதிகள் ≈ %3 $, 2f நாட்கள்)</string>
+    <string name="tx_locked">பரிவர்த்தனை தொகை தொகுதி %1$d வரை பூட்டப்பட்டுள்ளது ( %2$d தொகுதிகள் ≈ %3$,.2f நாட்கள்)</string>
     <string name="setting_theme">சூல் தண்டு</string>
     <string name="menu_cancel">ரத்துசெய்</string>
     <string name="title_info">தகவல்</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,6 +263,10 @@
     <string name="tx_notes">Notes</string>
     <string name="tx_notes_hint">(optional)</string>
     <string name="tx_title">Transaction Details</string>
+    <string name="menu_import_feather_notes">Import Feather CSV notes</string>
+    <string name="import_feather_notes_success">Imported %1$d transaction notes</string>
+    <string name="import_feather_notes_none">No matching transaction notes found</string>
+    <string name="import_feather_notes_error">Could not import Feather CSV: %1$s</string>
 
     <string name="tx_pending">PENDING</string>
     <string name="tx_failed">FAILED</string>

--- a/app/src/test/java/com/m2049r/xmrwallet/util/FeatherCsvTxNotesTest.java
+++ b/app/src/test/java/com/m2049r/xmrwallet/util/FeatherCsvTxNotesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 m2049r
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.m2049r.xmrwallet.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class FeatherCsvTxNotesTest {
+    @Test
+    public void parseFeatherHistoryCsv() throws Exception {
+        String csv = "blockHeight,timestamp,date,accountIndex,direction,balanceDelta,"
+                + "amount,fee,txid,description,paymentID,fiatAmount,fiatCurrency\n"
+                + "2317852,1615848678,2021-03-15T23:51:18Z,0,out,-0.2,"
+                + "0.2,0.000017,abc123,\"Donation, with comma\",,20.2,USD\n"
+                + "2317853,1615848699,2021-03-15T23:51:39Z,0,in,1,"
+                + "1,0,def456,\"note with \"\"quotes\"\"\",,?,USD\n";
+
+        FeatherCsvTxNotes.Result result = new FeatherCsvTxNotes().parse(new StringReader(csv));
+
+        assertEquals(2, result.rowsRead);
+        assertEquals(0, result.rowsSkipped);
+        assertEquals("Donation, with comma", result.notes.get("abc123"));
+        assertEquals("note with \"quotes\"", result.notes.get("def456"));
+    }
+
+    @Test
+    public void skipsRowsWithoutTxidOrDescription() throws Exception {
+        String csv = "txid,description\n"
+                + "abc123,\n"
+                + ",missing txid\n"
+                + "def456,keep me\n";
+
+        FeatherCsvTxNotes.Result result = new FeatherCsvTxNotes().parse(new StringReader(csv));
+
+        assertEquals(3, result.rowsRead);
+        assertEquals(2, result.rowsSkipped);
+        assertEquals(1, result.notes.size());
+        assertEquals("keep me", result.notes.get("def456"));
+    }
+
+    @Test
+    public void parsesMultilineDescriptions() throws Exception {
+        String csv = "txid,description\n"
+                + "abc123,\"first line\n"
+                + "second line\"\n";
+
+        FeatherCsvTxNotes.Result result = new FeatherCsvTxNotes().parse(new StringReader(csv));
+
+        assertEquals(1, result.rowsRead);
+        assertEquals("first line\nsecond line", result.notes.get("abc123"));
+    }
+
+    @Test(expected = IOException.class)
+    public void requiresFeatherColumns() throws Exception {
+        new FeatherCsvTxNotes().parse(new StringReader("hash,note\nabc,hello\n"));
+    }
+
+    @Test
+    public void parsesEmptyFile() throws Exception {
+        FeatherCsvTxNotes.Result result = new FeatherCsvTxNotes().parse(new StringReader(""));
+
+        assertTrue(result.notes.isEmpty());
+        assertEquals(0, result.rowsRead);
+        assertEquals(0, result.rowsSkipped);
+    }
+}


### PR DESCRIPTION
Fixes #1014.

Summary:
- add a Feather CSV transaction-note parser for the documented `txid` and `description` columns
- add a wallet menu action to pick a Feather CSV via Android's document picker
- import non-empty descriptions with `Wallet.setUserNote`, preserving existing Monerujo/xmr.to note metadata where present
- add unit coverage for quoted descriptions, commas, escaped quotes, missing values, missing columns, and empty files

Verification:
- `git diff --check`
- Not run: `./gradlew testProdMainnetDebugUnitTest --tests com.m2049r.xmrwallet.util.FeatherCsvTxNotesTest` because this local environment has no Java Runtime installed.

Bounty payout address (XMR):
`4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`
